### PR TITLE
LIBFCREPO-1497. Created the framework for the pluggable indexer modules and added discoverability indexer module.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,4 @@ test = [
 
 [project.entry-points.solrizer_indexers]
 content_model = "solrizer.indexers.content_model:content_model_fields"
+discoverability = "solrizer.indexers.discoverability:discoverability_fields"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "solrizer"
 version = "1.0.0-dev"
 dependencies = [
     "flask",
+    "langcodes",
     "plastron-client",
     "plastron-models",
     "plastron-rdf",
@@ -20,3 +21,6 @@ test = [
     "pytest-cov",
     "pytest-datadir",
 ]
+
+[project.entry-points.solrizer_indexers]
+content_model = "solrizer.indexers.content_model:content_model_fields"

--- a/src/solrizer/errors.py
+++ b/src/solrizer/errors.py
@@ -7,14 +7,30 @@ from werkzeug.exceptions import HTTPException, NotFound, BadRequest
 
 class ProblemDetailError(HTTPException):
     """Subclass of the Werkzeug `HTTPException` class that adds a `params`
-    dictionary that `as_problem_detail` uses to format the response details."""
+    dictionary that `as_problem_detail()` uses to format the response details."""
+
+    name: str
+    """Used as the problem detail `title`."""
+    description: str
+    """Used as the problem detail `details`. The value is treated as a format
+    string, and is filled in using the `params` dictionary."""
+
     def __init__(self, description=None, response=None, **params):
         super().__init__(description, response)
         self.params = params
 
     def as_problem_detail(self) -> dict[str, Any]:
         """Format the exception information as a dictionary with keys as
-        specified in the RFC 9457 JSON Problem Details format."""
+        specified in the [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)
+        JSON Problem Details format.
+
+        | RFC 9457 Key | Attribute |
+        |--------------|-----------|
+        | `"status"`   | `code`    |
+        | `"title"`    | `name`    |
+        | `"details"`  | `description`, formatted using the `params` dictionary |
+
+        """
         return {
             'status': self.code,
             'title': self.name,
@@ -23,17 +39,48 @@ class ProblemDetailError(HTTPException):
 
 
 class ResourceNotAvailable(ProblemDetailError, NotFound):
+    """The resource requested is unavailable. This may be due to insufficient
+    permissions to read the resource, or the resource simply not existing in
+    the repository.
+
+    The HTTP status is `404 Not Found`.
+
+    Must provide a `uri` parameter to the constructor:
+
+    ```python
+    raise ResourceNotAvailable(uri='http://example.com/foo')
+    ```
+    """
     name = 'Resource is not available'
     description = 'Resource at "{uri}" is not available from the repository.'
 
 
 class NoResourceRequested(ProblemDetailError, BadRequest):
+    """No resource was requested.
+
+    The HTTP status is `400 Bad Request`."""
     name = 'No resource requested'
     description = 'No resource URL or path was provided as part of this request.'
 
 
 def problem_detail_response(e: ProblemDetailError) -> Response:
-    """Return a JSON Problem Detail (RFC 9457) for HTTP errors."""
+    """Return a JSON Problem Detail ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457))
+    for HTTP errors.
+
+    This function is mainly intended to be registered as an error handler
+    with a Flask app:
+
+    ```python
+    from flask import Flask
+    from solrizer import problem_detail_response
+
+    app = Flask(__name__)
+
+    ...
+
+    app.register_error_handler(ProblemDetailError, problem_detail_response)
+    ```
+    """
     # start with the correct headers and status code from the error
     response = e.get_response()
     # replace the body with JSON

--- a/src/solrizer/indexers/__init__.py
+++ b/src/solrizer/indexers/__init__.py
@@ -1,0 +1,82 @@
+"""
+Indexers are implemented as functions that take an `IndexerContext` object
+as their single argument, and return a dictionary mapping Solr field names
+to values. The `IndexerContext` contains, among other things, a dictionary
+holding the accumulated output of multiple indexers. This dictionary is
+updated after each indexer runs, so later indexers have access to previous
+indexers outputs. (Note that there is no way to explicitly specify a
+dependency or ordering requirement on indexers, so any such dependencies
+will have to be manually reckoned with by the developers of such indexers.)
+
+Indexers are registered using the entry points specification in the
+`pyproject.toml` project metadata file, in the group `solrizer_indexers`:
+
+```toml
+[project.entry-points.solrizer_indexers]
+content_model = "solrizer.indexers.content_model:content_model_fields"
+```
+
+The key is the name that will be used later to look up the indexer,
+and the value is a `"package.path:function_name"` string.
+
+The indexers are run via the `IndexerContext.run()` instance method. It
+takes a list of indexer names to run, and returns the accumulated dictionary
+of fields suitable for sending to Solr.
+"""
+import importlib.metadata
+import logging
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Iterable
+
+from plastron.rdfmapping.resources import RDFResourceBase
+from plastron.repo import RepositoryResource, Repository
+
+type SolrFields = dict[str, str | int | list | dict]
+"""Type alias for Solr index document dictionaries."""
+
+AVAILABLE_INDEXERS = importlib.metadata.entry_points(group='solrizer_indexers')
+"""Available processors determined from the `solrizer.indexers` entry point
+group."""
+
+logger = logging.getLogger(__name__)
+
+
+class IndexerError(Exception):
+    pass
+
+
+@dataclass
+class IndexerContext[ModelType: RDFResourceBase]:
+    """Holds the necessary context information for indexing a single resource."""
+    repo: Repository
+    """Source repository of the resource."""
+    resource: RepositoryResource
+    """The resource being indexed."""
+    model_class: type[ModelType]
+    """The Plastron content model class of the resource."""
+    doc: SolrFields
+    """The current state of the Solr index document."""
+
+    @cached_property
+    def obj(self) -> ModelType:
+        """The `resource`, described using the `model_class`. This is a
+        cached property, so repeated calls to it will return the same object."""
+        return self.resource.describe(self.model_class)
+
+    def run(self, indexers: Iterable[str]) -> SolrFields:
+        """Runs each indexer in the `indexers` iterable, and returns the
+        final state of the Solr index document."""
+        for name in indexers:
+            try:
+                indexer = AVAILABLE_INDEXERS[name].load()
+            except KeyError as e:
+                raise IndexerError(f'No indexer named {e} is registered')
+
+            try:
+                self.doc.update(indexer(self))
+            except IndexerError as e:
+                logger.error(f'Unable to run indexer "{name}": {e}')
+                raise
+
+        return self.doc

--- a/src/solrizer/indexers/content_model.py
+++ b/src/solrizer/indexers/content_model.py
@@ -1,3 +1,25 @@
+"""
+Indexer Name: **`content_model`**
+
+Indexer implementation function: `content_model_fields()`
+
+Prerequisites: None
+
+Output field patterns:
+
+| Field pattern                 | Python Type            | Solr Type                   |
+|-------------------------------|------------------------|-----------------------------|
+| `{model}__{attr}__int`        | `int`                  | integer                     |
+| `{model}__{attr}__id`         | `str`                  | string                      |
+| `{model}__{attr}__dt`         | `datetime`             | datetime range              |
+| `{model}__{attr}__edtf`       | `str`                  | string                      |
+| `{model}__{attr}__txt`        | `str`                  | tokenized text              |
+| `{model}__{attr}__txt_{lang}` | `str`                  | tokenized text for `{lang}` |
+| `{model}__{attr}__uri`        | `str`                  | string                      |
+| `{model}__{attr}__curie`      | `str`                  | string                      |
+| `{model}__{attr}`             | `list[dict[str, ...]]` | nested document             |
+"""
+
 import logging
 from typing import Iterable, Callable, Iterator
 

--- a/src/solrizer/indexers/discoverability.py
+++ b/src/solrizer/indexers/discoverability.py
@@ -1,0 +1,13 @@
+from plastron.namespaces import umdaccess
+
+from solrizer.indexers import IndexerContext, SolrFields
+
+
+def discoverability_fields(ctx: IndexerContext) -> SolrFields:
+    fields = {
+        'is_published': umdaccess.Published in ctx.obj.rdf_type,
+        'is_hidden': umdaccess.Hidden in ctx.obj.rdf_type,
+        'is_top_level': any(str(v).startswith('http://vocab.lib.umd.edu/model#') for v in ctx.obj.rdf_type),
+    }
+    fields['is_discoverable'] = (fields['is_top_level'] and fields['is_published'] and not fields['is_hidden'])
+    return fields

--- a/src/solrizer/indexers/discoverability.py
+++ b/src/solrizer/indexers/discoverability.py
@@ -1,3 +1,20 @@
+"""
+Indexer Name: **`discoverability`**
+
+Indexer implementation function: `discoverability_fields()`
+
+Prerequisites: None
+
+Output fields:
+
+| Field             | Python Type | Solr Type |
+|-------------------|-------------|-----------|
+| `is_published`    | `bool`      | boolean   |
+| `is_hidden`       | `bool`      | boolean   |
+| `is_top_level`    | `bool`      | boolean   |
+| `is_discoverable` | `bool`      | boolean   |
+"""
+
 from plastron.namespaces import umdaccess
 
 from solrizer.indexers import IndexerContext, SolrFields

--- a/src/solrizer/web.py
+++ b/src/solrizer/web.py
@@ -48,7 +48,10 @@ def create_app():
         )
 
         try:
-            doc = ctx.run(['content_model'])
+            doc = ctx.run([
+                'content_model',
+                'discoverability',
+            ])
         except IndexerError as e:
             raise InternalServerError(f'Error while processing {uri} for indexing: {e}')
 

--- a/tests/indexers/test_content_model.py
+++ b/tests/indexers/test_content_model.py
@@ -12,6 +12,7 @@ from plastron.repo import Repository, RepositoryResource
 from plastron.validation.vocabularies import Vocabulary
 from rdflib import URIRef, Literal
 
+from solrizer.indexers import IndexerError
 from solrizer.indexers.content_model import get_model_fields, get_data_fields, shorten_uri, get_object_fields, \
     language_suffix
 
@@ -35,10 +36,17 @@ def test_shorten_uri(uri, expected_value):
         ('en', '_en'),
         ('en-US', '_en_us'),
         ('ja-Latn', '_ja_latn'),
+        ('jpn-LATN', '_ja_latn'),
+        ('ger', '_de'),
     ]
 )
 def test_language_suffix(language, expected_value):
     assert language_suffix(language) == expected_value
+
+
+def test_invalid_language_suffix():
+    with pytest.raises(IndexerError):
+        language_suffix('invalid::tag')
 
 
 @pytest.mark.parametrize(

--- a/tests/indexers/test_discoverability.py
+++ b/tests/indexers/test_discoverability.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+
+import pytest
+from plastron.namespaces import umdaccess, umd
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import Repository, RepositoryResource
+
+from solrizer.indexers import IndexerContext
+from solrizer.indexers.discoverability import discoverability_fields
+
+
+@pytest.mark.parametrize(
+    ('obj', 'expected_fields'),
+    [
+        (
+            RDFResource(),
+            {'is_published': False, 'is_hidden': False, 'is_top_level': False, 'is_discoverable': False},
+        ),
+        (
+            RDFResource(rdf_type=[umd.Item]),
+            {'is_published': False, 'is_hidden': False, 'is_top_level': True, 'is_discoverable': False},
+        ),
+        (
+            RDFResource(rdf_type=[umdaccess.Published, umd.Item]),
+            {'is_published': True, 'is_hidden': False, 'is_top_level': True, 'is_discoverable': True},
+        ),
+        (
+            RDFResource(rdf_type=[umdaccess.Published, umdaccess.Hidden, umd.Item]),
+            {'is_published': True, 'is_hidden': True, 'is_top_level': True, 'is_discoverable': False},
+        ),
+        (
+            RDFResource(rdf_type=[umdaccess.Published, umdaccess.Hidden]),
+            {'is_published': True, 'is_hidden': True, 'is_top_level': False, 'is_discoverable': False},
+        ),
+        (
+            RDFResource(rdf_type=[umdaccess.Published]),
+            {'is_published': True, 'is_hidden': False, 'is_top_level': False, 'is_discoverable': False},
+        ),
+    ]
+)
+def test_discoverability(monkeypatch, obj, expected_fields):
+    context = IndexerContext(
+        repo=MagicMock(spec=Repository),
+        resource=MagicMock(spec=RepositoryResource),
+        model_class=RDFResource,
+        doc={'id': 'foo'},
+    )
+    monkeypatch.setattr(context, 'obj', obj)
+    fields = discoverability_fields(context)
+    assert fields == expected_fields

--- a/tests/indexers/test_indexer_context.py
+++ b/tests/indexers/test_indexer_context.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+import pytest
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import Repository, RepositoryResource
+
+import solrizer.indexers
+from solrizer.indexers import IndexerError, IndexerContext
+
+
+@pytest.fixture
+def ctx():
+    return IndexerContext(
+        repo=MagicMock(spec=Repository),
+        resource=MagicMock(spec=RepositoryResource),
+        model_class=RDFResource,
+        doc={},
+    )
+
+
+def test_invalid_indexer(ctx):
+    with pytest.raises(IndexerError) as e:
+        ctx.run(['DOES_NOT_EXIST'])
+    assert str(e.value) == "No indexer named 'DOES_NOT_EXIST' is registered"
+
+
+def test_indexer_error(ctx, monkeypatch):
+    mock_indexer = MagicMock()
+    mock_indexer.load.return_value = mock_indexer
+    mock_indexer.side_effect = IndexerError('failed')
+    monkeypatch.setattr(solrizer.indexers, 'AVAILABLE_INDEXERS', {'foo': mock_indexer})
+    with pytest.raises(IndexerError) as e:
+        ctx.run(['foo'])
+    assert str(e.value) == 'failed'


### PR DESCRIPTION
Created the framework for the pluggable indexer modules:
- created IndexerContext class that encapsulates a resource, its model, and the dictionary of Solr fields being built
- standardized the indexer function as taking an IndexerContext argument and returning a dictionary of Solr fields
- moved the running of the indexer into the IndexerContext.run() instance method
- updated some parameter and type names
- added API documentation

Added discoverability indexer module:
* adds the "is_published", "is_hidden", "is_discoverable", and "is_top_level" fields
* registered as "discoverability" in the "solrizer_indexers" entry point group
* added more tests for IndexerContext