### PR TITLE
LIBFCREPO-1562. Added date_fields indexer.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "solrizer"
 version = "1.0.0-dev"
 dependencies = [
+    "edtf",
     "flask",
     "langcodes",
     "plastron-client",
@@ -28,3 +29,8 @@ content_model = "solrizer.indexers.content_model:content_model_fields"
 discoverability = "solrizer.indexers.discoverability:discoverability_fields"
 page_sequence = "solrizer.indexers.page_sequence:page_sequence_fields"
 iiif_links = "solrizer.indexers.iiif_links:iiif_links_fields"
+dates = "solrizer.indexers.dates:date_fields"
+
+[tool.pytest.ini_options]
+# the datetime.datetime.utcnow() warning is coming from the httpretty code
+filterwarnings = 'ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning'

--- a/src/solrizer/indexers/dates.py
+++ b/src/solrizer/indexers/dates.py
@@ -1,0 +1,122 @@
+"""
+Indexer Name: **`dates`**
+
+Indexer implementation function: `date_fields()`
+
+Prerequisites: Must run **after** the [`content_model`](./content_model) indexer
+
+Output field patterns:
+
+| Field pattern                                      | Python Type | Solr Type      |
+|----------------------------------------------------|-------------|----------------|
+| `{model}__{attr}__dt`                              | `str`       | datetime range |
+| `{model}__{attr}__dt_is_uncertain`                 | `bool`      | boolean        |
+| `{model}__{attr}__dt_is_approximate`               | `bool`      | boolean        |
+| `{model}__{attr}__dt_is_uncertain_and_approximate` | `bool`      | boolean        |
+"""
+
+import logging
+
+from edtf import parse_edtf, Date, UnspecifiedIntervalSection, EDTFObject, UncertainOrApproximate, Interval, Season, \
+    Unspecified, ExponentialYear, LongYear, EDTFParseException, DateAndTime
+
+from solrizer.indexers import IndexerContext, SolrFields
+
+logger = logging.getLogger(__name__)
+
+YMD_STRING = '{0:04d}-{1:02d}-{2:02d}'
+"""Formatting string used by `strict_range()` to generate `YYYY-MM-DD` strings."""
+
+
+def date_fields(ctx: IndexerContext) -> SolrFields:
+    """For any EDTF field in the index document (i.e., one whose name ends
+    with `__edtf`) creates a corresponding `__dt` field with a value that
+    is parseable by Solr as a date or date range. Populates three boolean
+    flag fields with the suffixes `__dt_is_uncertain`, `__dt_is_approximate`,
+    and `__dt_is_uncertain_and_approximate` that indicate whether the
+    EDTF string had the markers for uncertainty (`?`), approximation (`~`),
+    or both (`%`).
+
+    Emits a warning and skips any EDTF fields that cannot be represented
+    as Solr dates (e.g., exponential years, years with more than four digits),
+    or that cannot even be parsed as EDTF strings."""
+
+    # EDTF fields
+    for edtf_name in filter(lambda n: n.endswith('__edtf'), ctx.doc.keys()):
+        edtf_string = ctx.doc[edtf_name]
+        name = edtf_name.replace('__edtf', '')
+        try:
+            edtf: EDTFObject = parse_edtf(edtf_string)
+            return {
+                name + '__dt': solr_date(edtf),
+                name + '__dt_is_uncertain': edtf.is_uncertain,
+                name + '__dt_is_approximate': edtf.is_approximate,
+                name + '__dt_is_uncertain_and_approximate': edtf.is_uncertain_and_approximate
+            }
+        except UnsupportedEDTFValue as e:
+            logger.warning(f'Cannot convert "{edtf_string}" in field {edtf_name} to a Solr date: {e.reason}')
+        except EDTFParseException:
+            logger.warning(f'Cannot parse "{edtf_string}" in field {edtf_name} as an EDTF string')
+    else:
+        return {}
+
+
+def strict_range(edtf: Date) -> str:
+    """Format the given EDTF date as a Solr date range, using the strict
+    upper and lower bounds of the EDTF date."""
+
+    begin = YMD_STRING.format(*edtf.lower_strict()[:3])
+    end = YMD_STRING.format(*edtf.upper_strict()[:3])
+    return f'[{begin} TO {end}]'
+
+
+def solr_date(edtf_value: str | EDTFObject) -> str:
+    """Convert an EDTF string (or an already parsed `EDTFObject`) into
+    a date or date range string valid for Solr.
+
+    Raises an `UnsupportedEDTFValue` exception if the `edtf_value` cannot
+    be parsed or cannot be represented as a Solr datetime range."""
+
+    if isinstance(edtf_value, EDTFObject):
+        edtf = edtf_value
+    else:
+        edtf = parse_edtf(edtf_value)
+
+    match edtf:
+        case ExponentialYear():
+            if abs(int(edtf.exponent)) > 3:
+                raise UnsupportedEDTFValue(
+                    edtf=edtf,
+                    reason='Solr does not support years outside the range -9999 to 9999',
+                )
+            else:
+                return strict_range(edtf)
+        case LongYear():
+            raise UnsupportedEDTFValue(
+                edtf=edtf,
+                reason='Solr does not support years outside the range -9999 to 9999',
+            )
+        case Season() | Unspecified():
+            return strict_range(edtf)
+        case UnspecifiedIntervalSection():
+            return '*'
+        case Interval():
+            lower = edtf.lower
+            upper = edtf.upper
+            return f'[{solr_date(lower)} TO {solr_date(upper)}]'
+        case UncertainOrApproximate():
+            return str(edtf.date)
+        case Date() | DateAndTime():
+            return str(edtf)
+
+
+class UnsupportedEDTFValue(ValueError):
+    """Raised to indicate this is a valid EDTF string, but one that is not
+    translatable into a Solr date or date range."""
+
+    def __init__(self, *args, edtf: EDTFObject, reason: str = 'Solr does not support this EDTF value'):
+        super().__init__(*args)
+        self.edtf: EDTFObject = edtf
+        """The unsupported EDTF object"""
+        self.reason: str = reason
+        """The reason this `edtf` cannot be represented in Solr"""

--- a/src/solrizer/web.py
+++ b/src/solrizer/web.py
@@ -25,6 +25,7 @@ def create_app():
         'discoverability',
         'page_sequence',
         'iiif_links',
+        'dates',
     ]
     app.config['iiif_manifests_url_pattern'] = os.environ.get('IIIF_MANIFESTS_URL_PATTERN')
     app.config['iiif_thumbnail_url_pattern'] = os.environ.get('IIIF_THUMBNAIL_URL_PATTERN')

--- a/tests/indexers/test_dates.py
+++ b/tests/indexers/test_dates.py
@@ -1,0 +1,226 @@
+from unittest.mock import MagicMock
+
+import pytest
+from edtf import EDTFParseException
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import Repository, RepositoryResource
+
+from solrizer.indexers import IndexerContext
+from solrizer.indexers.dates import solr_date, date_fields, UnsupportedEDTFValue
+
+EDTF_TEST_STRINGS = [
+    ('1605-11-05','1605-11-05'),
+    ('2000-11','2000-11'),
+    ('1984','1984'),
+    ('2000-11-01/2014-12-01','[2000-11-01 TO 2014-12-01]'),
+    ('2004-06/2006-08','[2004-06 TO 2006-08]'),
+    ('1964/2008','[1964 TO 2008]'),
+    ('2014/2014-12-01','[2014 TO 2014-12-01]'),
+    ('../1985-04-12','[* TO 1985-04-12]'),
+    ('../1985-04','[* TO 1985-04]'),
+    ('../1985','[* TO 1985]'),
+    ('1985-04-12/..','[1985-04-12 TO *]'),
+    ('1985-04/..','[1985-04 TO *]'),
+    ('1985/..','[1985 TO *]'),
+    ('-0009', '-0009'),
+
+    # date and time
+    ('2024-09-03T12:06:34', '2024-09-03T12:06:34'),
+
+    # seasons, with hemisphere
+    # Note about year-wrapping (taken from a comment in edtf.appsettings):
+    #
+    # > winter in the northern hemisphere wraps the end of the year, so
+    # > Winter 2010 could wrap into 2011.
+    # > For simplicity, we assume it falls at the end of the year, esp since the
+    # > spec says that sort order goes spring > summer > autumn > winter
+
+    # northern hemisphere
+    # spring
+    ('2001-25','[2001-03-01 TO 2001-05-31]'),
+    # summer
+    ('2001-26','[2001-06-01 TO 2001-08-31]'),
+    # autumn
+    ('2001-27','[2001-09-01 TO 2001-11-30]'),
+    # winter
+    ('2001-28','[2001-12-01 TO 2001-12-31]'),
+
+    # southern hemisphere
+    # spring
+    ('2001-29','[2001-09-01 TO 2001-11-30]'),
+    # summer
+    ('2001-30','[2001-12-01 TO 2001-12-31]'),
+    # autumn
+    ('2001-31','[2001-03-01 TO 2001-05-31]'),
+    # winter
+    ('2001-32','[2001-06-01 TO 2001-08-31]'),
+
+    # other year subdivisions
+    # quarters (3-month blocks)
+    ('2001-33', '[2001-01-01 TO 2001-03-31]'),
+    ('2001-34', '[2001-04-01 TO 2001-06-30]'),
+    ('2001-35', '[2001-07-01 TO 2001-09-30]'),
+    ('2001-36', '[2001-10-01 TO 2001-12-31]'),
+    # quadrimesters (4-month blocks)
+    ('2001-37', '[2001-01-01 TO 2001-04-30]'),
+    ('2001-38', '[2001-05-01 TO 2001-08-31]'),
+    ('2001-39', '[2001-09-01 TO 2001-12-31]'),
+    # semesters (6-month blocks)
+    ('2001-40', '[2001-01-01 TO 2001-06-30]'),
+    ('2001-41', '[2001-07-01 TO 2001-12-31]'),
+
+    # unspecified digits
+    ('1992-09-XX', '[1992-09-01 TO 1992-09-30]'),
+    ('1992-XX', '[1992-01-01 TO 1992-12-31]'),
+    ('199X', '[1990-01-01 TO 1999-12-31]'),
+    ('19XX', '[1900-01-01 TO 1999-12-31]'),
+    ('1XXX', '[1000-01-01 TO 1999-12-31]'),
+    ('XXXX', '[0000-01-01 TO 9999-12-31]'),
+
+    # exponential years, as long as they are between -9999 and 9999
+    ('Y1E3', '[1000-01-01 TO 1000-12-31]'),
+    ('Y5E2', '[0500-01-01 TO 0500-12-31]'),
+    ('Y6E1', '[0060-01-01 TO 0060-12-31]'),
+    ('Y-1E3', '[-1000-01-01 TO -1000-12-31]'),
+    ('Y-5E2', '[-500-01-01 TO -500-12-31]'),
+    ('Y-6E1', '[-060-01-01 TO -060-12-31]'),
+]
+
+UNSUPPORTED_EDTF_STRINGS = [
+    # LongYear
+    'Y21000',
+    'Y-18000',
+    # ExponentialYear
+    'Y1E5',
+    'Y-2E6',
+]
+
+INVALID_EDTF_STRINGS = [
+    'Y1999-12-31',
+]
+
+
+@pytest.fixture
+def context_with_date():
+    def _context(edtf_value):
+        return IndexerContext(
+            repo=MagicMock(spec=Repository),
+            resource=MagicMock(spec=RepositoryResource),
+            model_class=RDFResource,
+            doc={
+                'date__edtf': edtf_value,
+            },
+            config={},
+        )
+    return _context
+
+
+@pytest.mark.parametrize(
+    ('edtf_value', 'expected_solr_value'),
+    EDTF_TEST_STRINGS,
+)
+def test_solr_date(edtf_value, expected_solr_value):
+    assert solr_date(edtf_value) == expected_solr_value
+
+
+@pytest.mark.parametrize(
+    ('edtf_value', 'expected_solr_value'),
+    EDTF_TEST_STRINGS,
+)
+def test_date_fields(edtf_value, expected_solr_value, context_with_date):
+    fields = date_fields(context_with_date(edtf_value))
+    assert fields['date__dt'] == expected_solr_value
+
+
+@pytest.mark.parametrize(
+    ('edtf_value', 'expected_solr_value', 'is_uncertain', 'is_approximate', 'is_uncertain_and_approximate'),
+    [
+        ('2024?', '2024', True, False, False),
+        ('2024~', '2024', False, True, False),
+        ('2024%', '2024', False, False, True),
+        ('2024?/2025', '[2024 TO 2025]', True, False, False),
+        ('2024~/2025', '[2024 TO 2025]', False, True, False),
+        ('2024%/2025', '[2024 TO 2025]', False, False, True),
+        ('2024?/2025?', '[2024 TO 2025]', True, False, False),
+        ('2024~/2025~', '[2024 TO 2025]', False, True, False),
+        ('2024%/2025%', '[2024 TO 2025]', False, False, True),
+        ('2024/2025?', '[2024 TO 2025]', True, False, False),
+        ('2024/2025~', '[2024 TO 2025]', False, True, False),
+        ('2024/2025%', '[2024 TO 2025]', False, False, True),
+        ('2024?/2025~', '[2024 TO 2025]', True, True, False),
+        ('2024~/2025?', '[2024 TO 2025]', True, True, False),
+        ('2024?/2025%', '[2024 TO 2025]', True, False, True),
+        ('2024~/2025%', '[2024 TO 2025]', False, True, True),
+    ]
+)
+def test_uncertain_and_or_approximate(
+    edtf_value,
+    expected_solr_value,
+    is_uncertain,
+    is_approximate,
+    is_uncertain_and_approximate,
+    context_with_date,
+):
+    expected_fields = {
+        'date__dt': expected_solr_value,
+        'date__dt_is_uncertain': is_uncertain,
+        'date__dt_is_approximate': is_approximate,
+        'date__dt_is_uncertain_and_approximate': is_uncertain_and_approximate,
+    }
+    assert date_fields(context_with_date(edtf_value)) == expected_fields
+
+
+@pytest.mark.parametrize(
+    'edtf_value',
+    UNSUPPORTED_EDTF_STRINGS,
+)
+def test_unsupported_edtf_solr_date(edtf_value):
+    with pytest.raises(UnsupportedEDTFValue):
+        solr_date(edtf_value)
+
+
+@pytest.mark.parametrize(
+    'edtf_value',
+    UNSUPPORTED_EDTF_STRINGS,
+)
+def test_unsupported_edtf_date_fields(edtf_value, context_with_date, caplog):
+    fields = date_fields(context_with_date(edtf_value))
+    assert fields == {}
+    assert f'Cannot convert "{edtf_value}"' in caplog.text
+
+
+@pytest.mark.parametrize(
+    'edtf_value',
+    INVALID_EDTF_STRINGS,
+)
+def test_edtf_parse_exception_solr_date(edtf_value):
+    with pytest.raises(EDTFParseException):
+        solr_date(edtf_value)
+
+
+@pytest.mark.parametrize(
+    'edtf_value',
+    INVALID_EDTF_STRINGS,
+)
+def test_edtf_parse_exception_solr_date(edtf_value, context_with_date, caplog):
+    fields = date_fields(context_with_date(edtf_value))
+    assert fields == {}
+    assert f'Cannot parse "{edtf_value}"' in caplog.text
+
+
+@pytest.mark.parametrize(
+    'edtf_value',
+    [
+        # LongYear
+        'Y21000',
+        'Y-18000',
+        # ExponentialYear
+        'Y1E5',
+        'Y-2E6',
+        # EDTF parse errors
+        'Y-12000/1982',
+    ]
+)
+def test_unsupported_edtf_returns_nothing(edtf_value, context_with_date):
+    fields = date_fields(context_with_date(edtf_value))
+    assert 'date__dt' not in fields


### PR DESCRIPTION
- registered as the "dates" indexer in the "solrizer_indexers" entry point group
- converts EDTF dates to Solr dates or date ranges, when possible
- skips any EDTF dates that cannot be parsed or converted to Solr dates
- in pytest ignore deprecation warning from third-party code (httpretty)

https://umd-dit.atlassian.net/browse/LIBFCREPO-1562