### PR TITLE
LIBFCREPO-1503. Updates to Solrizer needed to integrate with Solr and messaging.

### DIFF
--- a/src/solrizer/indexers/extracted_text.py
+++ b/src/solrizer/indexers/extracted_text.py
@@ -49,7 +49,7 @@ def extracted_text_fields(ctx: IndexerContext) -> SolrFields:
         text_pages.append(get_page_text(page_resource, n))
 
     return {
-        'content__dps_txt': ' '.join(str(p) for p in text_pages),
+        'content__dps_txt': ' '.join(str(p) for p in text_pages if p is not None),
     }
 
 

--- a/src/solrizer/web.py
+++ b/src/solrizer/web.py
@@ -93,7 +93,8 @@ def create_app():
 
         try:
             doc = ctx.run(app.config['INDEXERS'])
-        except IndexerError as e:
+        except (IndexerError, RuntimeError) as e:
+            app.logger.error(f'Error while processing {uri} for indexing: {e}')
             raise InternalServerError(f'Error while processing {uri} for indexing: {e}')
 
         return doc, {'Content-Type': 'application/json;charset=utf-8'}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,6 @@ def mock_vocabularies(monkeypatch, shared_datadir):
         return graph
 
     monkeypatch.setattr(plastron.validation.vocabularies, 'get_vocabulary_graph', _get_vocabulary_graph)
-    monkeypatch.setattr(plastron.models.authorities, 'get_vocabulary_graph', _get_vocabulary_graph)
 
     return _get_vocabulary_graph
 

--- a/tests/indexers/test_content_model.py
+++ b/tests/indexers/test_content_model.py
@@ -3,13 +3,14 @@ from unittest.mock import MagicMock
 
 import httpretty
 import pytest
-from plastron.models.authorities import VocabularyTerm, Subject
+from plastron.client import Endpoint
+from plastron.models.authorities import Subject, UMD_ARCHIVAL_COLLECTIONS
 from plastron.models.umd import Item
 from plastron.namespaces import umdtype, rdf, xsd, dcterms, owl
 from plastron.rdfmapping.properties import RDFDataProperty, RDFObjectProperty
 from plastron.rdfmapping.resources import RDFResource
 from plastron.repo import Repository, RepositoryResource
-from plastron.validation.vocabularies import Vocabulary
+from plastron.validation.vocabularies import VocabularyTerm
 from rdflib import URIRef, Literal
 
 from solrizer.indexers import IndexerError
@@ -129,7 +130,7 @@ def test_object_property_simple_with_curie():
 def test_object_property_from_vocabulary(datadir: Path):
     httpretty.register_uri(
         method=httpretty.GET,
-        uri='http://vocab.lib.umd.edu/collection#',
+        uri=UMD_ARCHIVAL_COLLECTIONS.uri,
         body=(datadir / 'collection.json').read_text(),
         adding_headers={'Content-Type': 'application/ld+json'},
     )
@@ -138,8 +139,8 @@ def test_object_property_from_vocabulary(datadir: Path):
         resource=resource,
         attr_name='archival_collection',
         predicate=dcterms.isPartOf,
-        object_class=VocabularyTerm,
-        values_from=Vocabulary('http://vocab.lib.umd.edu/collection#'),
+        object_class=VocabularyTerm.from_vocab(UMD_ARCHIVAL_COLLECTIONS),
+        values_from=UMD_ARCHIVAL_COLLECTIONS,
     )
     prop.add(URIRef('http://vocab.lib.umd.edu/collection#0051-MDHC'))
     repo = MagicMock(spec=Repository)
@@ -178,6 +179,7 @@ def test_object_property_linked():
     )
     prop.add(URIRef('http://example.com/fcrepo/foo/bar'))
     repo = MagicMock(spec=Repository)
+    repo.endpoint = Endpoint(url='http://example.com/fcrepo')
     repo_resource = MagicMock(spec=RepositoryResource)
     repo.__getitem__.return_value = repo_resource
     repo_resource.read.return_value = repo_resource

--- a/tests/indexers/test_content_model.py
+++ b/tests/indexers/test_content_model.py
@@ -60,7 +60,7 @@ def test_invalid_language_suffix():
         ('size', xsd.int, False, ['59'], {'size__int': 59}),
         ('size', xsd.integer, False, ['59'], {'size__int': 59}),
         ('size', xsd.long, False, ['59'], {'size__int': 59}),
-        ('timestamp', xsd.dateTime, False, ['2024-08-16'], {'timestamp__dt': '2024-08-16'}),
+        ('timestamp', xsd.dateTime, False, ['2024-08-16T14:54:18.240+00:00'], {'timestamp__dt': '2024-08-16T14:54:18.240000Z'}),
         (
             'value',
             None,

--- a/tests/indexers/test_content_model.py
+++ b/tests/indexers/test_content_model.py
@@ -61,7 +61,15 @@ def test_invalid_language_suffix():
         ('size', xsd.int, False, ['59'], {'size__int': 59}),
         ('size', xsd.integer, False, ['59'], {'size__int': 59}),
         ('size', xsd.long, False, ['59'], {'size__int': 59}),
-        ('timestamp', xsd.dateTime, False, ['2024-08-16T14:54:18.240+00:00'], {'timestamp__dt': '2024-08-16T14:54:18.240000Z'}),
+        (
+            'timestamp',
+            xsd.dateTime,
+            False,
+            ['2024-08-16T14:54:18.240+00:00'],
+            {
+                'timestamp__dt': '2024-08-16T14:54:18.240000Z',
+            }
+        ),
         (
             'value',
             None,


### PR DESCRIPTION
- added a converter to explicitly convert xsd:dateTime fields to Solr date format
- catch RuntimeErrors and return a 500
- improved get_linked_objects
  * if it is in the repo, fetch via the repo
  * if its object_class is a subclass of VocabularyTerm, use VocabularyTerm's machinery to fetch it
  * otherwise (currently) just return the URIRef
- only include pages with content in the full text field
- fix handling of controlled vocabulary fields

https://umd-dit.atlassian.net/browse/LIBFCREPO-1503