### PR TITLE
LIBFCREPO-1583. Support generation of indexing documents for nested child documents.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 5000
 
 ENV FLASK_DEBUG=0
 ENV SOLRIZER_IIIF_IDENTIFIER_PREFIX=fcrepo:
-ENV SOLRIZER_INDEXERS=content_model,discoverability,page_sequence,iiif_links,dates,facets
+ENV SOLRIZER_INDEXERS={"__default__":["content_model","discoverability","page_sequence","iiif_links","dates","facets","extracted_text"],"Page":["content_model"]}
 
 WORKDIR /opt/solrizer
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,8 @@ pipeline {
 
           pip install -e .[test]
 
-          pip install git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-utils \
+          pip install --force-reinstall \
+            git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-utils \
             git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-client \
             git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-rdf \
             git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-models \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,13 +100,14 @@ pipeline {
         sh '''
           apt-get update && apt-get install -y git && apt-get clean
           . .venv/bin/activate
+
+          pip install -e .[test]
+
           pip install git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-utils \
             git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-client \
             git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-rdf \
             git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-models \
             git+https://github.com/umd-lib/plastron.git@release/4.4#subdirectory=plastron-repo
-
-          pip install -e .[test]
         '''
       }
     }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SOLRIZER_FCREPO_JWT_TOKEN={authentication token}
 SOLRIZER_IIIF_IDENTIFIER_PREFIX=fcrepo:
 SOLRIZER_IIIF_MANIFESTS_URL_PATTERN={URI template for IIIF manifests}
 SOLRIZER_IIIF_THUMBNAIL_URL_PATTERN={URI template for IIIF thumbnail images}
-SOLRIZER_INDEXERS={"__default__":["content_model","discoverability","page_sequence","iiif_links","dates","facets","extracted_text"],"Page":["content_model"]}
+SOLRIZER_INDEXERS={"__default__":["content_model","discoverability","page_sequence","iiif_links","dates","facets","extracted_text"],"Page":["content_model","root"],"File":["content_model","root"]}
 ```
 
 In the IIIF URI templates, use `{+id}` as the placeholder for the IIIF 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ SOLRIZER_FCREPO_JWT_TOKEN={authentication token}
 SOLRIZER_IIIF_IDENTIFIER_PREFIX=fcrepo:
 SOLRIZER_IIIF_MANIFESTS_URL_PATTERN={URI template for IIIF manifests}
 SOLRIZER_IIIF_THUMBNAIL_URL_PATTERN={URI template for IIIF thumbnail images}
+SOLRIZER_INDEXERS={"__default__":["content_model","discoverability","page_sequence","iiif_links","dates","facets","extracted_text"],"Page":["content_model"]}
 ```
 
 In the IIIF URI templates, use `{+id}` as the placeholder for the IIIF 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ iiif_links = "solrizer.indexers.iiif_links:iiif_links_fields"
 dates = "solrizer.indexers.dates:date_fields"
 facets = "solrizer.indexers.facets:facet_fields"
 extracted_text = "solrizer.indexers.extracted_text:extracted_text_fields"
+root = "solrizer.indexers.root:root_field"
 
 [project.entry-points.solrizer_faceters]
 admin_set = "solrizer.faceters:AdminSetFacet"

--- a/src/solrizer/errors.py
+++ b/src/solrizer/errors.py
@@ -63,6 +63,21 @@ class NoResourceRequested(ProblemDetailError, BadRequest):
     description = 'No resource URL or path was provided as part of this request.'
 
 
+class UnknownCommand(ProblemDetailError, BadRequest):
+    """Unknown value provided for the "command" query parameter.
+
+    The HTTP status is `400 Bad Request`.
+
+    Must provide a `value` parameter to the constructor:
+
+    ```python
+    raise BadQueryParameter(value='foo')
+    ```
+    """
+    name = 'Unknown command'
+    description = '"{value}" is not a recognized value for the "command" parameter.'
+
+
 def problem_detail_response(e: ProblemDetailError) -> Response:
     """Return a JSON Problem Detail ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457))
     for HTTP errors.

--- a/src/solrizer/indexers/__init__.py
+++ b/src/solrizer/indexers/__init__.py
@@ -37,7 +37,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Iterable, Mapping, Any
 
-from plastron.rdfmapping.resources import RDFResourceBase
+from plastron.models import ContentModeledResource
 from plastron.repo import RepositoryResource, Repository
 
 type SolrFields = dict[str, str | int | list | dict]
@@ -55,7 +55,7 @@ class IndexerError(Exception):
 
 
 @dataclass
-class IndexerContext[ModelType: RDFResourceBase]:
+class IndexerContext[ModelType: ContentModeledResource]:
     """Holds the necessary context information for indexing a single resource."""
     repo: Repository
     """Source repository of the resource."""

--- a/src/solrizer/indexers/iiif_links.py
+++ b/src/solrizer/indexers/iiif_links.py
@@ -59,7 +59,7 @@ def iiif_links_fields(ctx: IndexerContext) -> SolrFields:
     )
     thumbnail_identifiers = [
         iiif_identifier(
-            repo_path=ctx.repo.endpoint.repo_path(page['pcdmobject__has_file'][0]['id']),
+            repo_path=ctx.repo.endpoint.repo_path(page['page__has_file'][0]['id']),
             prefix=ctx.config['IIIF_IDENTIFIER_PREFIX'],
         )
         for page in pages

--- a/src/solrizer/indexers/page_sequence.py
+++ b/src/solrizer/indexers/page_sequence.py
@@ -60,7 +60,7 @@ class PageSequence:
     @property
     def uris(self) -> list[str]:
         """The ordered list of page URIs."""
-        first_proxy = self.ctx.doc[f'{self.ctx.content_model_prefix}__first'][0]
+        first_proxy: dict[str, Any] = self.ctx.doc[f'{self.ctx.content_model_prefix}__first'][0]
         return [uri for uri in follow_sequence(first_proxy)]
 
     @property
@@ -69,7 +69,7 @@ class PageSequence:
         field of each page. If a page does not have a `pcdmobject__title__txt`
         field, uses `[Page N]`, where `N` is the position of the page in the
         sequence."""
-        return [page.get('pcdmobject__title__txt', f'[Page {n}]') for n, page in enumerate(self.pages, 1)]
+        return [str(page.get('pcdmobject__title__txt', f'[Page {n}]')) for n, page in enumerate(self.pages, 1)]
 
 
 def page_sequence_fields(ctx: IndexerContext) -> SolrFields:

--- a/src/solrizer/indexers/root.py
+++ b/src/solrizer/indexers/root.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from plastron.models import ContentModeledResource, guess_model
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import RepositoryResource
+from rdflib import URIRef
+
+from solrizer.indexers import IndexerContext, SolrFields, IndexerError
+
+
+def find_top_level_resource_uri(ctx: IndexerContext, obj: ContentModeledResource) -> Optional[URIRef]:
+    if hasattr(obj, 'member_of'):
+        parent_uri = obj.member_of.value
+    elif hasattr(obj, 'file_of'):
+        parent_uri = obj.file_of.value
+    else:
+        raise IndexerError(f'Unable to determine top-level parent of {obj.uri}')
+
+    parent_resource: RepositoryResource = ctx.repo.get_resource(parent_uri).read()
+    parent_model = guess_model(parent_resource.describe(RDFResource))
+    if parent_model.is_top_level:
+        return parent_uri
+    else:
+        return find_top_level_resource_uri(ctx, parent_resource.describe(parent_model))
+
+
+def root_field(ctx: IndexerContext) -> SolrFields:
+    if ctx.model_class.is_top_level:
+        return {}
+
+    obj = ctx.resource.describe(ctx.model_class)
+    uri = find_top_level_resource_uri(ctx, obj)
+    return {'_root_': str(uri)}

--- a/src/solrizer/indexers/root.py
+++ b/src/solrizer/indexers/root.py
@@ -1,3 +1,17 @@
+"""
+Indexer Name: **`root`**
+
+Indexer implementation function: `root_field()`
+
+Prerequisites: None
+
+Output fields:
+
+| Field    | Python Type | Solr Type |
+|----------|-------------|-----------|
+| `_root_` | `str`       | string    |
+"""
+
 from typing import Optional
 
 from plastron.models import ContentModeledResource, guess_model

--- a/src/solrizer/web.py
+++ b/src/solrizer/web.py
@@ -85,6 +85,8 @@ def create_app():
             app.logger.error(f'Unable to determine model class for {uri}')
             raise ResourceNotAvailable(uri=uri) from e
 
+        logger.info(f'Model class for {uri} is {model_class.__name__}')
+
         ctx = IndexerContext(
             repo=app.config['repo'],
             resource=resource,

--- a/tests/indexers/test_content_model.py
+++ b/tests/indexers/test_content_model.py
@@ -210,20 +210,22 @@ def test_get_model_fields():
     )
     repo = MagicMock(spec=Repository)
     expected_fields = {
-        'rdf_type__uris': ['http://vocab.lib.umd.edu/model#Item', 'http://pcdm.org/models#Object'],
-        'rdf_type__curies': ['umd:Item', 'pcdm:Object'],
-        'title__txt': 'Test Object',
-        'accession_number__id': '123',
-        'date__edtf': '2024-08',
-        'handle__id': 'hdl:1903.1/123',
-        'identifier__ids': ['tst-123'],
-        'archival_collection__uri': 'http://vocab.lib.umd.edu/collection#0051-MDHC',
-        'archival_collection__curie': 'http://vocab.lib.umd.edu/collection#0051-MDHC',
-        'archival_collection__label__txt': 'Maryland Conservation Council records',
-        'archival_collection__same_as__uris': ['http://hdl.handle.net/1903.1/1720'],
-        'archival_collection__same_as__curies': ['http://hdl.handle.net/1903.1/1720'],
+        'content_model_name__str': 'Item',
+        'content_model_prefix__str': 'item__',
+        'item__rdf_type__uris': ['http://vocab.lib.umd.edu/model#Item', 'http://pcdm.org/models#Object'],
+        'item__rdf_type__curies': ['umd:Item', 'pcdm:Object'],
+        'item__title__txt': 'Test Object',
+        'item__accession_number__id': '123',
+        'item__date__edtf': '2024-08',
+        'item__handle__id': 'hdl:1903.1/123',
+        'item__identifier__ids': ['tst-123'],
+        'item__archival_collection__uri': 'http://vocab.lib.umd.edu/collection#0051-MDHC',
+        'item__archival_collection__curie': 'http://vocab.lib.umd.edu/collection#0051-MDHC',
+        'item__archival_collection__label__txt': 'Maryland Conservation Council records',
+        'item__archival_collection__same_as__uris': ['http://hdl.handle.net/1903.1/1720'],
+        'item__archival_collection__same_as__curies': ['http://hdl.handle.net/1903.1/1720'],
     }
-    fields = get_model_fields(item, repo)
+    fields = get_model_fields(item, repo, prefix='item__')
     for k, v in fields.items():
         if isinstance(v, list):
             assert set(v) == set(expected_fields[k])

--- a/tests/indexers/test_iiif_links.py
+++ b/tests/indexers/test_iiif_links.py
@@ -23,13 +23,13 @@ def test_iiif_identifier(path, prefix, expected_identifier):
 
 def test_iiif_links_fields(monkeypatch, proxies):
     members = [
-        {'id': 'url1', 'pcdmobject__title__txt': 'Bar 1', 'pcdmobject__has_file': [
+        {'id': 'url1', 'page__title__txt': 'Bar 1', 'page__has_file': [
             {'id': 'http://example.com/fcrepo/foo/obj1/fileX'},
         ]},
-        {'id': 'url2', 'pcdmobject__title__txt': 'Bar 2', 'pcdmobject__has_file': [
+        {'id': 'url2', 'page__title__txt': 'Bar 2', 'page__has_file': [
             {'id': 'http://example.com/fcrepo/foo/obj2/fileX'},
         ]},
-        {'id': 'url3', 'pcdmobject__title__txt': 'Bar 3', 'pcdmobject__has_file': [
+        {'id': 'url3', 'page__title__txt': 'Bar 3', 'page__has_file': [
             {'id': 'http://example.com/fcrepo/foo/obj3/fileX'},
         ]},
     ]

--- a/tests/indexers/test_root.py
+++ b/tests/indexers/test_root.py
@@ -1,0 +1,137 @@
+from unittest.mock import MagicMock
+
+import pytest
+from plastron.models import ContentModeledResource
+from plastron.namespaces import dcterms, pcdm
+from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
+from plastron.repo import Repository, RepositoryResource
+from rdflib import URIRef
+
+import solrizer.indexers.root
+from solrizer.indexers import IndexerContext, IndexerError
+from solrizer.indexers.root import root_field
+
+
+class TopLevelModelClass(ContentModeledResource):
+    is_top_level = True
+
+    title = DataProperty(dcterms.title)
+
+
+class PageLevelModelClass(ContentModeledResource):
+    is_top_level = False
+
+    member_of = ObjectProperty(pcdm.memberOf, cls=TopLevelModelClass)
+
+
+class FileLevelModelClass(ContentModeledResource):
+    is_top_level = False
+
+    file_of = ObjectProperty(pcdm.fileOf, cls=PageLevelModelClass)
+
+
+# is marked as not top-level, but lacks any properties that could be
+# used to navigate to a parent resource (member_of or file_of)
+class OrphanModelClass(ContentModeledResource):
+    is_top_level = False
+
+
+def test_root_field_for_top_level():
+    context = IndexerContext(
+        repo=MagicMock(spec=Repository),
+        resource=MagicMock(spec=RepositoryResource),
+        model_class=TopLevelModelClass,
+        doc={},
+        config={},
+    )
+
+    assert root_field(context) == {}
+
+
+def test_root_field_for_page_level(monkeypatch):
+    monkeypatch.setattr(solrizer.indexers.root, 'guess_model', lambda _: TopLevelModelClass)
+    page_obj = PageLevelModelClass(uri='http://example.com/fcrepo/foo/p1', member_of=URIRef('http://example.com/fcrepo/foo'))
+    parent_obj = TopLevelModelClass(uri='http://example.com/fcrepo/foo')
+
+    repo = MagicMock(spec=Repository)
+
+    page_resource = MagicMock(spec=RepositoryResource)
+    page_resource.describe.return_value = page_obj
+
+    parent_resource = MagicMock(spec=RepositoryResource)
+    parent_resource.read.return_value = parent_resource
+    parent_resource.describe.return_value = parent_obj
+    repo.get_resource.return_value = parent_resource
+
+    context = IndexerContext(
+        repo=repo,
+        resource=page_resource,
+        model_class=PageLevelModelClass,
+        doc={},
+        config={},
+    )
+
+    fields = root_field(context)
+    assert fields['_root_'] == 'http://example.com/fcrepo/foo'
+
+
+def test_root_field_for_file_level(monkeypatch):
+    def _guess_model(obj):
+        if isinstance(obj, FileLevelModelClass):
+            return FileLevelModelClass
+        elif isinstance(obj, PageLevelModelClass):
+            return PageLevelModelClass
+        else:
+            return TopLevelModelClass
+
+    monkeypatch.setattr(solrizer.indexers.root, 'guess_model', _guess_model)
+
+    file_obj = FileLevelModelClass(uri='http://example.com/fcrepo/foo/p1/file', file_of=URIRef('http://example.com/fcrepo/foo/p1'))
+    page_obj = PageLevelModelClass(uri='http://example.com/fcrepo/foo/p1', member_of=URIRef('http://example.com/fcrepo/foo'))
+    root_obj = TopLevelModelClass(uri='http://example.com/fcrepo/foo')
+
+    repo = MagicMock(spec=Repository)
+
+    file_resource = MagicMock(spec=RepositoryResource)
+    file_resource.read.return_value = file_resource
+    file_resource.describe.return_value = file_obj
+
+    page_resource = MagicMock(spec=RepositoryResource)
+    page_resource.read.return_value = page_resource
+    page_resource.describe.return_value = page_obj
+
+    root_resource = MagicMock(spec=RepositoryResource)
+    root_resource.read.return_value = root_resource
+    root_resource.describe.return_value = root_obj
+
+    repo.get_resource.side_effect = [page_resource, root_resource]
+
+    context = IndexerContext(
+        repo=repo,
+        resource=file_resource,
+        model_class=FileLevelModelClass,
+        doc={},
+        config={},
+    )
+
+    fields = root_field(context)
+    assert fields['_root_'] == 'http://example.com/fcrepo/foo'
+
+
+def test_root_field_error(monkeypatch):
+    monkeypatch.setattr(solrizer.indexers.root, 'guess_model', lambda _: OrphanModelClass)
+
+    orphan_obj = OrphanModelClass()
+    orphan_resource = MagicMock(spec=RepositoryResource)
+    orphan_resource.read.return_value = orphan_resource
+    orphan_resource.describe.return_value = orphan_obj
+
+    context = IndexerContext(
+        repo=MagicMock(spec=Repository),
+        resource=orphan_resource,
+        model_class=OrphanModelClass,
+        doc={},
+        config={},
+    )
+    with pytest.raises(IndexerError):
+        root_field(context)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -47,7 +47,7 @@ def register_uri_for_reading(uri: str, content_type: str, body: str):
 
 @httpretty.activate()
 def test_doc_content_model_indexer_only(monkeypatch, client, datadir: Path):
-    monkeypatch.setitem(client.application.config, "INDEXERS", ['content_model'])
+    monkeypatch.setitem(client.application.config, "INDEXERS", {'__default__': ['content_model']})
     register_uri_for_reading(
         uri='http://example.com/fcrepo/foo',
         content_type='application/n-triples',


### PR DESCRIPTION
- Configure indexers per content model using a JSON map.
- Include the content_model fields if the object is an instance of a ContentModeled class.
  - fix up the field names to align with the correct Plastron content modeling
- Added root indexer that finds the parent object for child resources.
- Support a "command" query parameter.
  - modifies the JSON output based on the command:
    - "add" wraps the document in `{"add": {"doc": {...}}}`
    - "update" transforms the structure into an atomic update
  - added tests

https://umd-dit.atlassian.net/browse/LIBFCREPO-1583