### PR TITLE
LIBFCREPO-1591. Updated Solr date handling.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires-python = ">=3.12"
 
 [project.optional-dependencies]
 test = [
+    "freezegun",
     "httpretty",
     "pytest",
     "pytest-cov",
@@ -66,8 +67,12 @@ subject = "solrizer.faceters:SubjectFacet"
 visibility = "solrizer.faceters:VisibilityFacet"
 
 [tool.pytest.ini_options]
-# the datetime.datetime.utcnow() warning is coming from the httpretty code
-filterwarnings = 'ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning'
+# these warnings are coming from third-party code
+filterwarnings = [
+    'ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning',
+    'ignore:ConjunctiveGraph is deprecated:DeprecationWarning',
+    "ignore:The 'strip_cdata' option:DeprecationWarning",
+]
 
 [tool.ruff]
 line-length = 120

--- a/src/solrizer/indexers/content_model.py
+++ b/src/solrizer/indexers/content_model.py
@@ -21,7 +21,6 @@ Output field patterns:
 """
 
 import logging
-from datetime import datetime, timezone
 from typing import Iterable, Callable, Iterator
 
 from langcodes import standardize_tag, LanguageTagError
@@ -34,14 +33,9 @@ from plastron.validation.vocabularies import VocabularyTerm
 from rdflib import Literal, URIRef
 
 from solrizer.indexers import SolrFields, IndexerContext, IndexerError
+from solrizer.indexers.utils import solr_datetime
 
 logger = logging.getLogger(__name__)
-
-
-def solr_date(dt_string: str) -> str:
-    dt = datetime.fromisoformat(dt_string).astimezone(timezone.utc)
-    return dt.isoformat(sep='T').replace('+00:00', 'Z')
-
 
 FIELD_ARGUMENTS_BY_DATATYPE = {
     # integer types
@@ -49,7 +43,7 @@ FIELD_ARGUMENTS_BY_DATATYPE = {
     xsd.integer: {'suffix': '__int', 'converter': int},
     xsd.long: {'suffix': '__int', 'converter': int},
     # datetime type
-    xsd.dateTime: {'suffix': '__dt', 'converter': solr_date},
+    xsd.dateTime: {'suffix': '__dt', 'converter': solr_datetime},
     # identifier types
     umdtype.accessionNumber: {'suffix': '__id'},
     umdtype.handle: {'suffix': '__id'},

--- a/src/solrizer/indexers/dates.py
+++ b/src/solrizer/indexers/dates.py
@@ -21,6 +21,7 @@ from edtf import parse_edtf, Date, UnspecifiedIntervalSection, EDTFObject, Uncer
     Unspecified, ExponentialYear, LongYear, EDTFParseException, DateAndTime
 
 from solrizer.indexers import IndexerContext, SolrFields
+from solrizer.indexers.utils import solr_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -106,8 +107,10 @@ def solr_date(edtf_value: str | EDTFObject) -> str:
             return f'[{solr_date(lower)} TO {solr_date(upper)}]'
         case UncertainOrApproximate():
             return str(edtf.date)
-        case Date() | DateAndTime():
+        case Date():
             return str(edtf)
+        case DateAndTime():
+            return solr_datetime(str(edtf))
 
 
 class UnsupportedEDTFValue(ValueError):

--- a/src/solrizer/indexers/utils.py
+++ b/src/solrizer/indexers/utils.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timezone
+
+
+def solr_datetime(dt_string: str) -> str:
+    """Parse the given `dt_string` as an ISO 8601 timestamp, convert its
+    timezone to UTC, and use the "Z" timezone marker that Solr expects
+    instead of "+00:00".
+
+    At minimum, the `dt_string` must be a fully qualified date
+    in the format `YYYY-MM-DD`. Other abbreviated formats (such
+    as `YYYY` or `YYYY-MM`) will result in a `ValueError`.
+
+    If no time is specified, this function depends on the `datetime`
+    library's behavior of defaulting the time to midnight (00:00:00)
+    in local time."""
+    dt = datetime.fromisoformat(dt_string).astimezone(timezone.utc)
+    return dt.isoformat(sep='T').replace('+00:00', 'Z')

--- a/tests/indexers/test_dates.py
+++ b/tests/indexers/test_dates.py
@@ -24,7 +24,8 @@ EDTF_TEST_STRINGS = [
     ('1985/..', '[1985 TO *]'),
     ('-0009', '-0009'),
     # date and time
-    ('2024-09-03T12:06:34', '2024-09-03T12:06:34'),
+    # normalize to UTC (with the "Z" notation)
+    ('2024-11-18T11:49:32-05:00', '2024-11-18T16:49:32Z'),
     # seasons, with hemisphere
     # Note about year-wrapping (taken from a comment in edtf.appsettings):
     #

--- a/tests/indexers/test_utils.py
+++ b/tests/indexers/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+from freezegun import freeze_time
+
+from solrizer.indexers.utils import solr_datetime
+
+
+@pytest.mark.parametrize(
+    'dt_string',
+    [
+        '2024',
+        '2024-11',
+        'NOT A DATE',
+    ]
+
+)
+def test_solr_datetime_invalid_strings(dt_string):
+    with pytest.raises(ValueError):
+        solr_datetime(dt_string)
+
+
+@pytest.mark.parametrize(
+    ('dt_string', 'expected_value'),
+    [
+        ('2024-11-19', '2024-11-19T05:00:00Z'),
+        ('2024-11-19T09', '2024-11-19T14:00:00Z'),
+        ('2024-11-19T09:17', '2024-11-19T14:17:00Z'),
+        ('2024-11-19T09:17:32', '2024-11-19T14:17:32Z'),
+        ('2024-11-19T09:17:32-08:00', '2024-11-19T17:17:32Z'),
+        ('2024-11-19T09:17:32+00:00', '2024-11-19T09:17:32Z'),
+    ]
+)
+@freeze_time(tz_offset=-5)
+def test_solr_datetime(dt_string, expected_value):
+    assert solr_datetime(dt_string) == expected_value


### PR DESCRIPTION
- moved the `solr_date()` function from `solrizer.indexers.content_model` into a comman `solrizer.indexer.utils` module, and renamed it `solr_datetime()`
- only call `solr_datetime()` when we need to normalize a full date and time value form EDTF; if it is just a date it can get added as-is to Solr as the value of a DateRange field
- use freezegun to test `solr_datetime()` with a fixed and known time zone
- filter out additional third-party deprecation warnings when running pytest

https://umd-dit.atlassian.net/browse/LIBFCREPO-1591