### PR TITLE
LIBFCREPO-1617. Allow substitutions in the config files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ SOLRIZER_FCREPO_JWT_TOKEN={authentication token}
 SOLRIZER_IIIF_IDENTIFIER_PREFIX=fcrepo:
 SOLRIZER_IIIF_MANIFESTS_URL_PATTERN={URI template for IIIF manifests}
 SOLRIZER_IIIF_THUMBNAIL_URL_PATTERN={URI template for IIIF thumbnail images}
-SOLRIZER_INDEXERS={"__default__":["content_model","discoverability","page_sequence","iiif_links","dates","facets","extracted_text"],"Page":["content_model","root"],"File":["content_model","root"]}
+SOLRIZER_INDEXERS_FILE=indexers.yml
+SOLRIZER_INDEXER_SETTINGS_FILE=indexer-settings.yml
+SOLRIZER_HANDLE_PROXY_PREFIX={URL of handle proxy server}
 ```
 
 In the IIIF URI templates, use `{+id}` as the placeholder for the IIIF 

--- a/indexer-settings.yml
+++ b/indexer-settings.yml
@@ -1,5 +1,5 @@
 handles:
-  proxy_base_url: http://hdl.handle.net/
+  proxy_prefix: ${HANDLE_PROXY_PREFIX}
   possible_handle_fields:
     - archival_collection__same_as__uris
     - accession_number__id

--- a/src/solrizer/indexers/handles.py
+++ b/src/solrizer/indexers/handles.py
@@ -18,8 +18,8 @@ from plastron.models import ContentModeledResource
 from plastron.namespaces import umdtype
 from plastron.rdfmapping.properties import RDFDataProperty
 
+from solrizer.handles import Handle
 from solrizer.indexers import IndexerContext, SolrFields
-from solrizer.handles import Handle, HandleValueError
 
 
 def handle_fields(ctx: IndexerContext) -> SolrFields:
@@ -27,13 +27,13 @@ def handle_fields(ctx: IndexerContext) -> SolrFields:
     `find_handle_property()` to get the first property of the context object
     that has a `umdtype:handle` datatype."""
     fields = {}
-    proxy_base_url = ctx.settings.get('proxy_base_url', None)
+    proxy_prefix = ctx.settings.get('proxy_prefix', None)
     if prop := find_handle_property(ctx.obj):
-        handle = Handle.parse(prop.value, proxy_base_url)
+        handle = Handle.parse(prop.value, proxy_prefix)
         fields.update({
             'handle__id': str(handle),
             'handle__uri': handle.info_uri,
-            'handle_proxied__uri': handle.proxy_url(proxy_base_url)
+            'handle_proxied__uri': handle.proxy_url(proxy_prefix)
         })
 
     return fields

--- a/tests/indexers/test_handles.py
+++ b/tests/indexers/test_handles.py
@@ -54,7 +54,7 @@ def context_with_settings(monkeypatch):
 
 
 def test_handle_fields(context_with_settings):
-    ctx = context_with_settings({'proxy_base_url': 'http://example.net/hdl/'})
+    ctx = context_with_settings({'proxy_prefix': 'http://example.net/hdl/'})
     fields = handle_fields(ctx)
     assert fields['handle__id'] == '1903.1/123'
     assert fields['handle__uri'] == 'info:hdl/1903.1/123'


### PR DESCRIPTION
Use `envsubst` from `plastron.utils` to allow for substitutions in the config files loaded from the `*_FILE` environment variables. The mapping of values that can be substituted is the applications current `config`, so it has access to any environment variables prefixed with `SOLRIZER_` in their non-prefixed form.

Renamed `proxy_base_url` to `proxy_prefix` to better align with naming in other systems.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1617