### PR TITLE
LIBFCREPO-1634. Build page sequence by crawling the proxy chain.

### DIFF
--- a/src/solrizer/indexers/__init__.py
+++ b/src/solrizer/indexers/__init__.py
@@ -33,8 +33,8 @@ doc = ctx.run(['content_model', 'discoverability', 'page_sequence'])
 """
 import importlib.metadata
 import logging
-from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from collections.abc import Iterable, Mapping, MutableMapping
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any
 
@@ -70,6 +70,8 @@ class IndexerContext[ModelType: ContentModeledResource]:
     """Additional configuration."""
     settings: Mapping[str, Any] = None
     """Alias to configuration for the currently executing indexer."""
+    data: MutableMapping[str, Any] = field(default_factory=dict)
+    """Arbitrary data to be shared between indexers"""
 
     @property
     def content_model_prefix(self) -> str:

--- a/src/solrizer/indexers/content_model.py
+++ b/src/solrizer/indexers/content_model.py
@@ -76,6 +76,14 @@ FIELD_ARGUMENTS_BY_ATTR_NAME = {
 }
 """Field mappings for fields with particular property names."""
 
+SKIP_FIELDS_BY_MODEL = {
+    'Issue': {'first'},
+    'Item': {'first'},
+    'Letter': {'first'},
+    'Poster': {'first'},
+}
+"""Field names that should be skipped for each model."""
+
 
 def content_model_fields(ctx: IndexerContext) -> SolrFields:
     """Indexer function that adds fields generated from the indexed
@@ -97,12 +105,17 @@ def get_model_fields(obj: RDFResourceBase, repo: Repository, prefix: str = '') -
             'content_model_prefix__str': prefix,
         }
     else:
+        model_name = None
         fields = {}
 
     for prop in obj.rdf_properties():
         if len(prop) == 0:
             # skip properties with no values
             logger.debug(f'Skipping empty property {prop.attr_name}')
+            continue
+        if prop.attr_name in SKIP_FIELDS_BY_MODEL.get(model_name, set()):
+            # explicitly skip these properties
+            logger.debug(f'Skipping property {prop.attr_name} of model {model_name}')
             continue
         if isinstance(prop, RDFDataProperty):
             fields.update(get_data_fields(prop, prefix))

--- a/src/solrizer/indexers/iiif_links.py
+++ b/src/solrizer/indexers/iiif_links.py
@@ -53,7 +53,7 @@ def iiif_links_fields(ctx: IndexerContext) -> SolrFields:
     manifest_uri_template = URITemplate(ctx.config['IIIF_MANIFESTS_URL_PATTERN'])
     thumbnail_uri_template = URITemplate(ctx.config['IIIF_THUMBNAIL_URL_PATTERN'])
 
-    pages = PageSequence(ctx)
+    pages = ctx.data.get('page_sequence', PageSequence(ctx))
     identifier = iiif_identifier(
         repo_path=ctx.resource.path,
         prefix=ctx.config['IIIF_IDENTIFIER_PREFIX'],

--- a/tests/indexers/test_iiif_links.py
+++ b/tests/indexers/test_iiif_links.py
@@ -1,9 +1,9 @@
-from unittest.mock import MagicMock
-
 import pytest
-from plastron.client import Client, Endpoint
+from plastron.models.ldp import LDPContainer
+from plastron.models.ore import Proxy
 from plastron.models.umd import Item
-from plastron.repo import Repository, RepositoryResource
+from plastron.repo.pcdm import ProxyIterator
+from rdflib import URIRef
 
 from solrizer.indexers import IndexerContext
 from solrizer.indexers.iiif_links import iiif_identifier, iiif_links_fields
@@ -21,26 +21,33 @@ def test_iiif_identifier(path, prefix, expected_identifier):
     assert iiif_identifier(path, prefix) == expected_identifier
 
 
-def test_iiif_links_fields(monkeypatch, proxies):
+def test_iiif_links_fields(monkeypatch, proxies, create_mock_repo):
     members = [
-        {'id': 'url1', 'page__title__txt': 'Bar 1', 'page__has_file': [
+        {'id': '/url1', 'page__title__txt': 'Bar 1', 'page__has_file': [
             {'id': 'http://example.com/fcrepo/foo/obj1/fileX'},
         ]},
-        {'id': 'url2', 'page__title__txt': 'Bar 2', 'page__has_file': [
+        {'id': '/url2', 'page__title__txt': 'Bar 2', 'page__has_file': [
             {'id': 'http://example.com/fcrepo/foo/obj2/fileX'},
         ]},
-        {'id': 'url3', 'page__title__txt': 'Bar 3', 'page__has_file': [
+        {'id': '/url3', 'page__title__txt': 'Bar 3', 'page__has_file': [
             {'id': 'http://example.com/fcrepo/foo/obj3/fileX'},
         ]},
     ]
+    mock_repo = create_mock_repo({
+        '/proxy1': Proxy(proxy_for=URIRef('/url1'), next=URIRef('/proxy2')),
+        '/proxy2': Proxy(proxy_for=URIRef('/url2'), next=URIRef('/proxy3')),
+        '/proxy3': Proxy(proxy_for=URIRef('/url3')),
+        '/foo': Item(first=URIRef('/proxy1')),
+        '/foo/f': LDPContainer(),
+        '/foo/m': LDPContainer(),
+    })
     ctx = IndexerContext(
-        repo=Repository(client=Client(endpoint=Endpoint('http://example.com/fcrepo'))),
-        resource=MagicMock(spec=RepositoryResource, path='/foo'),
+        repo=mock_repo,
+        resource=mock_repo['/foo'],
         model_class=Item,
         doc={
             'id': 'http://example.com/fcrepo/foo',
             'item__has_member': members,
-            'item__first': [proxies]
         },
         config={
             'IIIF_IDENTIFIER_PREFIX': 'fcrepo:',


### PR DESCRIPTION
- skip indexing the proxy chain in the content_model indexer by skipping the "first" property
- cache the uri list for reuse later
- created more sophisticated tests

https://umd-dit.atlassian.net/browse/LIBFCREPO-1634