### PR TITLE
LIBFCREPO-1633. Handle qualified individual components of EDTF dates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ RUN pip install \
 COPY src pyproject.toml /opt/solrizer/
 RUN pip install -e .
 
+# install patched version of python-edtf (see https://umd-dit.atlassian.net/browse/LIBFCREPO-1633)
+pip install git+https://github.com/peichman-umd/python-edtf.git@68f0b36deee03a355e6bec9f255d718f0d9f032b
+
 ENTRYPOINT [ "solrizer" ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ source .venv/bin/activate
 pip install -e '.[dev,test]'
 ```
 
+Currently (2025-04-06), Solrizer requires a patched version of the 
+[python-edtf] module to correctly handle certain Level 2 [EDTF] date ranges. 
+To install it from GitHub:
+
+```zsh
+pip install git+https://github.com/peichman-umd/python-edtf.git@68f0b36deee03a355e6bec9f255d718f0d9f032b
+```
+
+The [Dockerfile](Dockerfile) includes this patch as well.
+
 Create a `.env` file with the following contents:
 
 ```
@@ -86,3 +96,7 @@ docker run --rm -it -p 5000:5000 --env-file .env docker.lib.umd.edu/solrizer
 
 See the [LICENSE](LICENSE.md) file for license rights and
 limitations (Apache 2.0).
+
+
+[python-edtf]: https://pypi.org/project/edtf/
+[EDTF]: https://www.loc.gov/standards/datetime/

--- a/src/solrizer/indexers/dates.py
+++ b/src/solrizer/indexers/dates.py
@@ -16,9 +16,11 @@ Output field patterns:
 """
 
 import logging
+from datetime import datetime
 
-from edtf import parse_edtf, Date, UnspecifiedIntervalSection, EDTFObject, UncertainOrApproximate, Interval, Season, \
-    Unspecified, ExponentialYear, LongYear, EDTFParseException, DateAndTime
+from edtf import (parse_edtf, Date, UnspecifiedIntervalSection, EDTFObject, UncertainOrApproximate, Interval,
+                  Level2Interval, Season, Unspecified, ExponentialYear, LongYear, EDTFParseException, DateAndTime,
+                  PartialUncertainOrApproximate)
 
 from solrizer.indexers import IndexerContext, SolrFields
 from solrizer.indexers.utils import solr_datetime
@@ -71,7 +73,7 @@ def strict_range(edtf: Date) -> str:
     return f'[{begin} TO {end}]'
 
 
-def solr_date(edtf_value: str | EDTFObject) -> str:
+def solr_date(edtf_value: str | EDTFObject, partial_ua_method: str = 'lower_strict') -> str:
     """Convert an EDTF string (or an already parsed `EDTFObject`) into
     a date or date range string valid for Solr.
 
@@ -101,12 +103,19 @@ def solr_date(edtf_value: str | EDTFObject) -> str:
             return strict_range(edtf)
         case UnspecifiedIntervalSection():
             return '*'
+        case Level2Interval():
+            lower = edtf.lower
+            upper = edtf.upper
+            return f'[{solr_date(lower, 'lower_strict')} TO {solr_date(upper, 'upper_strict')}]'
         case Interval():
             lower = edtf.lower
             upper = edtf.upper
             return f'[{solr_date(lower)} TO {solr_date(upper)}]'
         case UncertainOrApproximate():
             return str(edtf.date)
+        case PartialUncertainOrApproximate():
+            time_data = getattr(edtf, partial_ua_method)()
+            return str(datetime(*time_data[:7]).date())
         case Date():
             return str(edtf)
         case DateAndTime():

--- a/tests/indexers/test_dates.py
+++ b/tests/indexers/test_dates.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from edtf import EDTFParseException
-from plastron.rdfmapping.resources import RDFResource
+from plastron.models import ContentModeledResource
 from plastron.repo import Repository, RepositoryResource
 
 from solrizer.indexers import IndexerContext
@@ -100,7 +100,7 @@ def context_with_date():
         return IndexerContext(
             repo=MagicMock(spec=Repository),
             resource=MagicMock(spec=RepositoryResource),
-            model_class=RDFResource,
+            model_class=ContentModeledResource,
             doc={
                 'date__edtf': edtf_value,
             },
@@ -146,6 +146,13 @@ def test_date_fields(edtf_value, expected_solr_value, context_with_date):
         ('2024~/2025?', '[2024 TO 2025]', True, True, False),
         ('2024?/2025%', '[2024 TO 2025]', True, False, True),
         ('2024~/2025%', '[2024 TO 2025]', False, True, True),
+        # qualified individual components
+        ('~1945/1959', '[1945-01-01 TO 1959]', False, True, False),
+        ('1945/~1959', '[1945 TO 1959-12-31]', False, True, False),
+        ('1945-~06/1959', '[1945-06-01 TO 1959]', False, True, False),
+        ('1945/1959~-06', '[1945 TO 1959-06-30]', False, True, False),
+        ('1945-06~-15/1959', '[1945-06-15 TO 1959]', False, True, False),
+        ('1945/1959-06-~15', '[1945 TO 1959-06-15]', False, True, False),
     ],
 )
 def test_uncertain_and_or_approximate(


### PR DESCRIPTION
Requires the patched python-edtf library from https://github.com/peichman-umd/python-edtf/commit/68f0b36deee03a355e6bec9f255d718f0d9f032b

- added to the Dockerfile
- added to the README setup instructions

https://umd-dit.atlassian.net/browse/LIBFCREPO-1633