### PR TITLE
LIBFCREPO-1640. Handle KeyError in iiif_links page__has_file lookup.

### DIFF
--- a/src/solrizer/indexers/iiif_links.py
+++ b/src/solrizer/indexers/iiif_links.py
@@ -19,6 +19,7 @@ Output fields:
 | `iiif_thumbnail_sequence__ids`        | `list[str]` | multivalued string |
 | `iiif_thumbnail_sequence__uris`       | `list[str]` | multivalued string |
 """
+from typing import Any
 
 from uritemplate import URITemplate
 
@@ -58,16 +59,27 @@ def iiif_links_fields(ctx: IndexerContext) -> SolrFields:
         repo_path=ctx.resource.path,
         prefix=ctx.config['IIIF_IDENTIFIER_PREFIX'],
     )
-    thumbnail_identifiers = [
-        iiif_identifier(
-            repo_path=ctx.repo.endpoint.repo_path(page['page__has_file'][0]['id']),
-            prefix=ctx.config['IIIF_IDENTIFIER_PREFIX'],
-        )
-        for page in pages
-    ]
+    thumbnail_identifiers = [get_first_file_identifier(ctx, page) for page in pages]
     return {
         'iiif_manifest__id': identifier,
         'iiif_manifest__uri': manifest_uri_template.expand(id=identifier),
         'iiif_thumbnail_sequence__ids': thumbnail_identifiers,
         'iiif_thumbnail_sequence__uris': [thumbnail_uri_template.expand(id=id) for id in thumbnail_identifiers],
     }
+
+
+def get_first_file_identifier(ctx: IndexerContext, page: SolrFields) -> str:
+    """Given an `IndexerContext` and a page dictionary, returns the IIIF
+    identifier for the first file of that page, or "static:unavailable" if
+    the URI of the first file cannot be retrieved from the `page` for any
+    reason."""
+    try:
+        file: dict[str, Any] = page['page__has_file'][0]
+        file_uri = file['id']
+    except KeyError:
+        return 'static:unavailable'
+    else:
+        return iiif_identifier(
+            repo_path=ctx.repo.endpoint.repo_path(file_uri),
+            prefix=ctx.config['IIIF_IDENTIFIER_PREFIX'],
+        )

--- a/tests/indexers/test_iiif_links.py
+++ b/tests/indexers/test_iiif_links.py
@@ -2,11 +2,42 @@ import pytest
 from plastron.models.ldp import LDPContainer
 from plastron.models.ore import Proxy
 from plastron.models.umd import Item
-from plastron.repo.pcdm import ProxyIterator
 from rdflib import URIRef
 
 from solrizer.indexers import IndexerContext
 from solrizer.indexers.iiif_links import iiif_identifier, iiif_links_fields
+
+
+@pytest.fixture
+def mock_repo(create_mock_repo):
+    return create_mock_repo({
+        '/proxy1': Proxy(proxy_for=URIRef('/url1'), next=URIRef('/proxy2')),
+        '/proxy2': Proxy(proxy_for=URIRef('/url2'), next=URIRef('/proxy3')),
+        '/proxy3': Proxy(proxy_for=URIRef('/url3')),
+        '/foo': Item(first=URIRef('/proxy1')),
+        '/foo/f': LDPContainer(),
+        '/foo/m': LDPContainer(),
+    })
+
+
+@pytest.fixture
+def create_ctx(mock_repo):
+    def _ctx(members):
+        return IndexerContext(
+            repo=mock_repo,
+            resource=mock_repo['/foo'],
+            model_class=Item,
+            doc={
+                'id': 'http://example.com/fcrepo/foo',
+                'object__has_member': members,
+            },
+            config={
+                'IIIF_IDENTIFIER_PREFIX': 'fcrepo:',
+                'IIIF_THUMBNAIL_URL_PATTERN': 'http://iiif.example.com/thumbnail/{+id}',
+                'IIIF_MANIFESTS_URL_PATTERN': 'http://iiif.example.com/manifest/{+id}',
+            },
+        )
+    return _ctx
 
 
 @pytest.mark.parametrize(
@@ -21,7 +52,7 @@ def test_iiif_identifier(path, prefix, expected_identifier):
     assert iiif_identifier(path, prefix) == expected_identifier
 
 
-def test_iiif_links_fields(monkeypatch, proxies, create_mock_repo):
+def test_iiif_links_fields(proxies, create_ctx):
     members = [
         {'id': '/url1', 'page__title__txt': 'Bar 1', 'page__has_file': [
             {'id': 'http://example.com/fcrepo/foo/obj1/fileX'},
@@ -33,29 +64,7 @@ def test_iiif_links_fields(monkeypatch, proxies, create_mock_repo):
             {'id': 'http://example.com/fcrepo/foo/obj3/fileX'},
         ]},
     ]
-    mock_repo = create_mock_repo({
-        '/proxy1': Proxy(proxy_for=URIRef('/url1'), next=URIRef('/proxy2')),
-        '/proxy2': Proxy(proxy_for=URIRef('/url2'), next=URIRef('/proxy3')),
-        '/proxy3': Proxy(proxy_for=URIRef('/url3')),
-        '/foo': Item(first=URIRef('/proxy1')),
-        '/foo/f': LDPContainer(),
-        '/foo/m': LDPContainer(),
-    })
-    ctx = IndexerContext(
-        repo=mock_repo,
-        resource=mock_repo['/foo'],
-        model_class=Item,
-        doc={
-            'id': 'http://example.com/fcrepo/foo',
-            'object__has_member': members,
-        },
-        config={
-            'IIIF_IDENTIFIER_PREFIX': 'fcrepo:',
-            'IIIF_THUMBNAIL_URL_PATTERN': 'http://iiif.example.com/thumbnail/{+id}',
-            'IIIF_MANIFESTS_URL_PATTERN': 'http://iiif.example.com/manifest/{+id}',
-        },
-    )
-    fields = iiif_links_fields(ctx)
+    fields = iiif_links_fields(create_ctx(members))
     assert fields == {
         'iiif_manifest__id': 'fcrepo:foo',
         'iiif_manifest__uri': 'http://iiif.example.com/manifest/fcrepo:foo',
@@ -66,6 +75,33 @@ def test_iiif_links_fields(monkeypatch, proxies, create_mock_repo):
         ],
         'iiif_thumbnail_sequence__uris': [
             'http://iiif.example.com/thumbnail/fcrepo:foo:obj1:fileX',
+            'http://iiif.example.com/thumbnail/fcrepo:foo:obj2:fileX',
+            'http://iiif.example.com/thumbnail/fcrepo:foo:obj3:fileX',
+        ]
+    }
+
+
+def test_iiif_links_no_file_on_page(proxies, create_ctx):
+    members = [
+        {'id': '/url1', 'page__title__txt': 'Bar 1'},
+        {'id': '/url2', 'page__title__txt': 'Bar 2', 'page__has_file': [
+            {'id': 'http://example.com/fcrepo/foo/obj2/fileX'},
+        ]},
+        {'id': '/url3', 'page__title__txt': 'Bar 3', 'page__has_file': [
+            {'id': 'http://example.com/fcrepo/foo/obj3/fileX'},
+        ]},
+    ]
+    fields = iiif_links_fields(create_ctx(members))
+    assert fields == {
+        'iiif_manifest__id': 'fcrepo:foo',
+        'iiif_manifest__uri': 'http://iiif.example.com/manifest/fcrepo:foo',
+        'iiif_thumbnail_sequence__ids': [
+            'static:unavailable',
+            'fcrepo:foo:obj2:fileX',
+            'fcrepo:foo:obj3:fileX',
+        ],
+        'iiif_thumbnail_sequence__uris': [
+            'http://iiif.example.com/thumbnail/static:unavailable',
             'http://iiif.example.com/thumbnail/fcrepo:foo:obj2:fileX',
             'http://iiif.example.com/thumbnail/fcrepo:foo:obj3:fileX',
         ]


### PR DESCRIPTION
If there is no `page__has_file` item, or it is an empty list, uses "static:unavailable" for the thumbnail identifier.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1640