### PR TITLE
LIBFCREPO-1662. Added "described_by" indexer.

### DIFF
--- a/indexers.yml
+++ b/indexers.yml
@@ -1,5 +1,6 @@
 Item:
   - content_model
+  - described_by
   - discoverability
   - page_sequence
   - iiif_links
@@ -10,6 +11,7 @@ Item:
   - extracted_text
 Issue:
   - content_model
+  - described_by
   - discoverability
   - page_sequence
   - iiif_links
@@ -20,9 +22,11 @@ Issue:
   - extracted_text
 Page:
   - content_model
+  - described_by
   - root
 File:
   - content_model
+  - described_by
   - root
 AdminSet:
   - content_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ extracted_text = "solrizer.indexers.extracted_text:extracted_text_fields"
 root = "solrizer.indexers.root:root_field"
 handles = "solrizer.indexers.handles:handle_fields"
 aggregate_fields = "solrizer.indexers.aggregate_fields:aggregate_fields"
+described_by = "solrizer.indexers.described_by:described_by_field"
 
 [project.entry-points.solrizer_faceters]
 admin_set = "solrizer.faceters:AdminSetFacet"

--- a/src/solrizer/indexers/described_by.py
+++ b/src/solrizer/indexers/described_by.py
@@ -1,0 +1,24 @@
+"""
+Indexer Name: **`described_by`**
+
+Indexer implementation function: `described_by_field`
+
+Prerequisites: None
+
+Output fields:
+
+| Field               | Python Type | Solr Type |
+|---------------------|-------------|-----------|
+| `described_by__uri` | `str`       | string    |
+"""
+
+from solrizer.indexers import IndexerContext, SolrFields
+
+
+def described_by_field(ctx: IndexerContext) -> SolrFields:
+    """If the resource being indexed has a `description_url` (typically, this is only set
+    for non-RDF sources), this indexer uses that value for the `described_by__uri` field.
+    Otherwise, it falls back to the `url` on the assumption that the resource is an RDF
+    source (i.e., it is self-describing)."""
+
+    return {'described_by__uri': str(ctx.resource.description_url or ctx.resource.url)}

--- a/tests/indexers/test_described_by.py
+++ b/tests/indexers/test_described_by.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+import pytest
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import RepositoryResource, Repository
+
+from solrizer.indexers import IndexerContext
+from solrizer.indexers.described_by import described_by_field
+
+
+@pytest.mark.parametrize(
+    ('url', 'description_url', 'expected_value'),
+    [
+        (
+            'http://example.com/fcrepo/rest/123',
+            'http://example.com/fcrepo/rest/123/fcr:metadata',
+            'http://example.com/fcrepo/rest/123/fcr:metadata',
+        ),
+        # when the `description_url` is None (i.e., this is an RDF source),
+        # should fall back to using the plain `url` for the `described_by__uri` field
+        (
+            'http://example.com/fcrepo/rest/123',
+            None,
+            'http://example.com/fcrepo/rest/123',
+        ),
+    ]
+)
+def test_described_by(url, description_url, expected_value):
+    mock_resource = MagicMock(spec=RepositoryResource)
+    mock_resource.url = url
+    mock_resource.description_url = description_url
+    context = IndexerContext(
+        repo=MagicMock(spec=Repository),
+        resource=mock_resource,
+        model_class=RDFResource,
+        doc={'id': 'foo'},
+        config={},
+    )
+    fields = described_by_field(context)
+    assert fields['described_by__uri'] == expected_value


### PR DESCRIPTION
- adds a "described_by__uri" field
- contains the description URL of the resource; for binaries in Fedora 4 this is the resource URI plus the string "/fcr:metadata"; however, this implementation relies on the value from the resource HTTP headers obtained by the Plastron client

https://umd-dit.atlassian.net/browse/LIBFCREPO-1662