### PR TITLE
LIBFCREPO-1667. Proper Solr atomic update generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ source .venv/bin/activate
 ```
 
 Currently (2025-05-06), Solrizer requires a patched version of the 
-[python-edtf] module to correctly handle certain Level 2 [EDTF] date 
-ranges, and it should be installed before the other dependencies. 
+[python-edtf](https://pypi.org/project/edtf/) module to correctly 
+handle certain Level 2 [EDTF](https://www.loc.gov/standards/datetime/)
+date ranges, and it should be installed before the other dependencies. 
 
 ```zsh
 pip install git+https://github.com/peichman-umd/python-edtf.git@68f0b36deee03a355e6bec9f255d718f0d9f032b
@@ -40,6 +41,7 @@ SOLRIZER_IIIF_THUMBNAIL_URL_PATTERN={URI template for IIIF thumbnail images}
 SOLRIZER_INDEXERS_FILE=indexers.yml
 SOLRIZER_INDEXER_SETTINGS_FILE=indexer-settings.yml
 SOLRIZER_HANDLE_PROXY_PREFIX={URL of handle proxy server}
+SOLRIZER_SOLR_QUERY_ENDPOINT={URL of Solr query service}
 ```
 
 In the IIIF URI templates, use `{+id}` as the placeholder for the IIIF 
@@ -100,7 +102,3 @@ docker run --rm -it -p 5000:5000 --env-file .env docker.lib.umd.edu/solrizer
 
 See the [LICENSE](LICENSE.md) file for license rights and
 limitations (Apache 2.0).
-
-
-[python-edtf]: https://pypi.org/project/edtf/
-[EDTF]: https://www.loc.gov/standards/datetime/

--- a/src/solrizer/solr.py
+++ b/src/solrizer/solr.py
@@ -1,0 +1,58 @@
+import requests
+
+from solrizer.indexers import SolrFields
+
+
+def create_atomic_update(doc: SolrFields, solr_query_endpoint: str):
+    """ Transform the `doc` into an
+    [atomic update](https://solr.apache.org/guide/solr/9_6/indexing-guide/partial-document-updates.html#atomic-updates)
+    using the `solr_query_endpoint` URL to get the current version of the document
+    from the index and running a diff against `doc` to find changed keys."""
+
+    response = requests.get(solr_query_endpoint, params={'ids': doc['id']})
+    try:
+        old_doc = response.json()['response']['docs'][0]
+    except (IndexError, KeyError):
+        old_doc = {}
+
+    return atomic_diff(old_doc, doc)
+
+
+COPY_KEYS = {'id', '_root_'}
+"""Copy these keys verbatim into the atomic update."""
+SKIP_KEYS = {'_version_'}
+"""Skip these keys when creating the atomic update."""
+
+
+def atomic_diff(old_doc: SolrFields, new_doc: SolrFields) -> dict:
+    """Create a Solr atomic update structure based on the changes from the
+    `old_doc` to the `new_doc`."""
+
+    diff = {}
+    for key in old_doc.keys():
+        if key in COPY_KEYS:
+            # copy these keys verbatim
+            diff[key] = old_doc[key]
+        elif key in SKIP_KEYS:
+            # ignore these keys
+            continue
+        elif key not in new_doc:
+            # field was removed between old and new doc
+            diff[key] = {'set': None}
+        else:
+            if old_doc[key] == new_doc[key]:
+                # no change, ignore
+                continue
+            else:
+                # value of an existing field was updated
+                diff[key] = {'set': new_doc[key]}
+    for key in filter(lambda k: k not in old_doc, new_doc.keys()):
+        # new field
+        if key in COPY_KEYS:
+            diff[key] = new_doc[key]
+        elif key in SKIP_KEYS:
+            continue
+        else:
+            diff[key] = {'set': new_doc[key]}
+
+    return diff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,14 @@ from uuid import uuid4
 import plastron.models.authorities
 import plastron.validation.vocabularies
 import pytest
+from httpretty import httpretty
 from plastron.client import Endpoint
 from plastron.models import ContentModeledResource
 from plastron.repo import RepositoryResource, Repository
 from plastron.repo.pcdm import PCDMObjectResource, ProxyIterator
 from rdflib import Graph, URIRef
 
-from solrizer.indexers import SolrFields, IndexerContext
+from solrizer.indexers import SolrFields
 from solrizer.web import create_app
 
 
@@ -101,3 +102,20 @@ def get_mock_resource():
         mock_resource.describe.return_value = obj
         return mock_resource
     return _mock_resource
+
+
+@pytest.fixture
+def register_uri_for_reading():
+    def _register_uri_for_reading(uri: str, content_type: str, body: str):
+        httpretty.register_uri(
+            method=httpretty.HEAD,
+            uri=uri,
+            adding_headers={'Content-Type': content_type},
+        )
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=uri,
+            body=body,
+            adding_headers={'Content-Type': content_type},
+        )
+    return _register_uri_for_reading

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -37,22 +38,8 @@ def test_doc_repository_error(app, client):
     assert detail['details'] == 'Resource at "http://example.com/fcrepo/foo" is not available from the repository.'
 
 
-def register_uri_for_reading(uri: str, content_type: str, body: str):
-    httpretty.register_uri(
-        method=httpretty.HEAD,
-        uri=uri,
-        adding_headers={'Content-Type': content_type},
-    )
-    httpretty.register_uri(
-        method=httpretty.GET,
-        uri=uri,
-        body=body,
-        adding_headers={'Content-Type': content_type},
-    )
-
-
 @httpretty.activate()
-def test_doc_content_model_indexer_only(monkeypatch, client, datadir: Path):
+def test_doc_content_model_indexer_only(monkeypatch, client, datadir: Path, register_uri_for_reading):
     monkeypatch.setitem(client.application.config, "INDEXERS", {'__default__': ['content_model']})
     register_uri_for_reading(
         uri='http://example.com/fcrepo/foo',
@@ -69,7 +56,7 @@ def test_doc_content_model_indexer_only(monkeypatch, client, datadir: Path):
 
 
 @httpretty.activate()
-def test_doc_no_content_model(client, repo):
+def test_doc_no_content_model(client, repo, register_uri_for_reading):
     register_uri_for_reading(
         uri='http://example.com/fcrepo/foo',
         content_type='application/n-triples',
@@ -86,7 +73,7 @@ def test_doc_no_content_model(client, repo):
 
 
 @httpretty.activate()
-def test_doc_with_add_command(datadir, client, repo):
+def test_doc_with_add_command(datadir, client, repo, register_uri_for_reading):
     register_uri_for_reading(
         uri='http://example.com/fcrepo/foo',
         content_type='application/n-triples',
@@ -105,13 +92,20 @@ def test_doc_with_add_command(datadir, client, repo):
 
 
 @httpretty.activate()
-def test_doc_with_update_command(datadir, client, repo):
+def test_doc_with_update_command(datadir, client, repo, register_uri_for_reading):
     register_uri_for_reading(
         uri='http://example.com/fcrepo/foo',
         content_type='application/n-triples',
         body=(datadir / 'item.nt').read_text(),
     )
+    register_uri_for_reading(
+        uri='http://solr.example.com/fcrepo/select',
+        content_type='application/json',
+        body=json.dumps({'response': {'docs': [{
+            'id': 'http://example.com/fcrepo/foo', 'object__title__txt_de': 'der Hund', 'object__title__txt': 'Moonpig'}]}}),
+    )
     client.application.config['repo'] = repo
+    client.application.config['SOLR_QUERY_ENDPOINT'] = 'http://solr.example.com/fcrepo/select'
     response = client.get('/doc?uri=http://example.com/fcrepo/foo&command=update')
     assert response.status_code == 200
     assert response.mimetype == 'application/json'
@@ -123,7 +117,7 @@ def test_doc_with_update_command(datadir, client, repo):
 
 
 @httpretty.activate()
-def test_doc_with_unknown_command(datadir, client, repo):
+def test_doc_with_unknown_command(datadir, client, repo, register_uri_for_reading):
     register_uri_for_reading(
         uri='http://example.com/fcrepo/foo',
         content_type='application/n-triples',

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -1,0 +1,86 @@
+import json
+
+import httpretty
+import pytest
+
+from solrizer.solr import atomic_diff, create_atomic_update
+
+
+@pytest.mark.parametrize(
+    ('old_doc', 'new_doc', 'expected_diff'),
+    [
+        # no changes
+        (
+            {'id': 'foo', 'object__title__txt': 'Foo'},
+            {'id': 'foo', 'object__title__txt': 'Foo'},
+            {'id': 'foo'},
+        ),
+        # new value for existing field
+        (
+            {'id': 'foo', 'object__title__txt': 'Foo'},
+            {'id': 'foo', 'object__title__txt': 'Bar'},
+            {'id': 'foo', 'object__title__txt': {'set': 'Bar'}},
+        ),
+        # new value for existing field, skip "_version_"
+        (
+            {'id': 'foo', '_version_': 1234, 'object__title__txt': 'Foo'},
+            {'id': 'foo', 'object__title__txt': 'Bar'},
+            {'id': 'foo', 'object__title__txt': {'set': 'Bar'}},
+        ),
+        # remove one field, add another
+        (
+            {'id': 'foo', 'object__title__txt': 'Foo'},
+            {'id': 'foo', 'object__title__txt_en': 'Bar'},
+            {
+                'id': 'foo',
+                'object__title__txt': {'set': None},
+                'object__title__txt_en': {'set': 'Bar'},
+            },
+        ),
+        # update values in nested documents
+        (
+            {
+                'id': 'foo',
+                'title': 'Moonpig',
+                'pages': [
+                    {'id': 'p1', '_root_': 'foo', 'title': 'Page I'},
+                    {'id': 'p2', '_root_': 'foo', 'title': 'Page 2'},
+                ]
+            },
+            {
+                'id': 'foo',
+                'title': 'Moonpig',
+                'pages': [
+                    {'id': 'p1', '_root_': 'foo', 'title': 'Page I'},
+                    {'id': 'p2', '_root_': 'foo', 'title': 'Page II'},
+                ]
+            },
+            {
+                'id': 'foo',
+                'pages': {
+                    'set': [
+                        {'id': 'p1', '_root_': 'foo', 'title': 'Page I'},
+                        {'id': 'p2', '_root_': 'foo', 'title': 'Page II'},
+                    ],
+                },
+            }
+        )
+    ]
+)
+def test_atomic_diff(old_doc, new_doc, expected_diff):
+    assert atomic_diff(old_doc, new_doc) == expected_diff
+
+
+@httpretty.activate()
+def test_create_atomic_update_no_old_doc(register_uri_for_reading):
+    register_uri_for_reading(
+        uri='http://solr.example.com/fcrepo/select',
+        content_type='application/json',
+        body=json.dumps({'response': {'docs': []}}),
+    )
+    new_doc = {'id': 'foo', 'title': 'Foo'}
+    atomic_update = create_atomic_update(
+        new_doc,
+        solr_query_endpoint='http://solr.example.com/fcrepo/select',
+    )
+    assert atomic_update == {'id': 'foo', 'title': {'set': 'Foo'}}


### PR DESCRIPTION
If the requested command is "update", attempt to read the existing document from Solr as the basis for constructing a field-by-field atomic update document.

- added `SOLRIZER_SOLR_QUERY_ENDPOINT` to the list of environment variables
- moved the `register_uri_for_reading` helper function into conftest.py as a fixture

https://umd-dit.atlassian.net/browse/LIBFCREPO-1667