### PR TITLE
LIBFCREPO-1665. Pre-sort the `*__display` fields.

### DIFF
--- a/tests/indexers/test_get_resource_language.py
+++ b/tests/indexers/test_get_resource_language.py
@@ -1,0 +1,34 @@
+from plastron.models import ContentModeledResource
+from plastron.namespaces import dcterms
+from plastron.rdfmapping.descriptors import DataProperty
+from rdflib import Literal
+
+from solrizer.indexers.content_model import get_resource_language
+
+
+class ModelWithLanguage(ContentModeledResource):
+    language = DataProperty(dcterms.language)
+
+
+def test_get_resource_language_no_language_property():
+    obj = ContentModeledResource()
+    assert get_resource_language(obj) is None
+
+
+def test_get_resource_language_no_value():
+    obj = ModelWithLanguage()
+    assert get_resource_language(obj) is None
+
+
+def test_get_resource_language():
+    obj = ModelWithLanguage(language=Literal('en'))
+    assert get_resource_language(obj) == 'en'
+
+
+class ModelMitSprache(ContentModeledResource):
+    sprache = DataProperty(dcterms.language)
+
+
+def test_get_resource_language_alternate_prop_name():
+    obj = ModelMitSprache(sprache=Literal('de'))
+    assert get_resource_language(obj, prop_name='sprache') == 'de'


### PR DESCRIPTION
Sort order:

1. Language-tagged values in a preferred language, by value
2. Language-tagged values, by language tag and value
3. Non-language tagged values, by value

Sorting by language tag uses the normalized tag versions, and sorting by value is case insensitive.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1665