### PR TITLE
LIBFCREPO-1798. Added drill-down date facets.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "configurenv",
     "edtf",
     "flask",
+    "humanize",
     "jq",
     "langcodes",
     "plastron-client>=4.7.0",

--- a/src/solrizer/indexers/dates.py
+++ b/src/solrizer/indexers/dates.py
@@ -17,11 +17,16 @@ Output field patterns:
 """
 
 import logging
+import re
+from calendar import month_name
 from datetime import datetime
+from typing import NamedTuple
 
 from edtf import (parse_edtf, Date, UnspecifiedIntervalSection, EDTFObject, UncertainOrApproximate, Interval,
                   Level2Interval, Season, Unspecified, ExponentialYear, LongYear, EDTFParseException, DateAndTime,
                   PartialUncertainOrApproximate, OneOfASet, Consecutives)
+from humanize import ordinal
+
 from solrizer.indexers import IndexerContext, SolrFields
 from solrizer.indexers.utils import solr_datetime
 
@@ -66,13 +71,18 @@ def date_fields(ctx: IndexerContext) -> SolrFields:
         name = edtf_name.replace('__edtf', '')
         try:
             edtf: EDTFObject = parse_edtf(str(edtf_string))
-            return {
+            fields = {
                 name + '__dt': solr_date(edtf),
                 name + '__dt_is_uncertain': edtf.is_uncertain,
                 name + '__dt_is_approximate': edtf.is_approximate,
                 name + '__dt_is_uncertain_and_approximate': edtf.is_uncertain_and_approximate,
                 name + '__dt_precision__int': get_precision(edtf),
             }
+            if facetable_date := _get_facetable_date(edtf):
+                date_facets = EDTFFacets(facetable_date).get_facets(prefix=f'{name}_', suffix='__facet')
+                fields.update(date_facets)
+
+            return fields
         except UnsupportedEDTFValue as e:
             logger.warning(f'Cannot convert "{edtf_string}" in field {edtf_name} to a Solr date: {e.reason}')
         except EDTFParseException:
@@ -170,6 +180,113 @@ def _get_upper_and_lower_precisions(edtf: Interval | Consecutives):
         get_precision(edtf.upper),
     ]
     return [p for p in precisions if p is not None]
+
+
+def _get_facetable_date(edtf: EDTFObject) -> Date | None:
+    match edtf:
+        case Date():
+            return edtf
+        case DateAndTime():
+            return edtf.date
+        case _:
+            return None
+
+
+class EDTFFacetValue(NamedTuple):
+    sort_value: str
+    label: str
+
+    def __str__(self):
+        return f'{self.sort_value}|{self.label}'
+
+
+SPECIFIED_MILLENNIUM = re.compile(r'\d\d\d[\dX]|\d\d[\dX]X|\d[\dX]XX')
+SPECIFIED_CENTURY = re.compile(r'\d\d\d[\dX]|\d\d[\dX]X')
+SPECIFIED_DECADE = re.compile(r'\d\d\d[\dX]')
+SPECIFIED_YEAR = re.compile(r'\d\d\d')
+UNSPECIFIED_VALUE = EDTFFacetValue('Unspecified', 'Unspecified')
+
+
+class EDTFFacets:
+    def __init__(self, edtf_value: Date):
+        self._date = edtf_value
+        self._year = self._date.year
+
+    @property
+    def millennium(self) -> EDTFFacetValue:
+        if self._year and SPECIFIED_MILLENNIUM.match(self._year):
+            y = self._year[0:1]
+            millennium = ordinal(int(y) + 1)
+            return EDTFFacetValue(
+                f'{y}XXX',
+                f'{millennium} Millennium ({y}000-{y}999)',
+            )
+        else:
+            return UNSPECIFIED_VALUE
+
+    @property
+    def century(self) -> EDTFFacetValue:
+        if self._year and SPECIFIED_CENTURY.match(self._year):
+            yy = self._year[0:2]
+            century = ordinal(int(yy) + 1)
+            return EDTFFacetValue(
+                f'{yy}XX',
+                f'{century} Century ({yy}00-{yy}99)',
+            )
+        else:
+            return UNSPECIFIED_VALUE
+
+    @property
+    def decade(self) -> EDTFFacetValue:
+        if self._year and SPECIFIED_DECADE.match(self._year):
+            yyy = self._year[0:3]
+            decade = f'{yyy}0s'.removeprefix('0').removeprefix('0')
+            return EDTFFacetValue(
+                f'{yyy}X',
+                f'{decade} ({yyy}0-{yyy}9)',
+            )
+        else:
+            return UNSPECIFIED_VALUE
+
+    @property
+    def year(self) -> EDTFFacetValue:
+        if self._year and SPECIFIED_YEAR.match(self._year):
+            return EDTFFacetValue(
+                self._year,
+                self._year.lstrip('0'),
+            )
+        else:
+            return UNSPECIFIED_VALUE
+
+    @property
+    def month(self) -> EDTFFacetValue:
+        if not isinstance(self._date, Season) and self._date.month and 'X' not in self._date.month:
+            return EDTFFacetValue(
+                str(self._date.month),
+                month_name[int(str(self._date.month))],
+            )
+        else:
+            return UNSPECIFIED_VALUE
+
+    @property
+    def day(self) -> EDTFFacetValue:
+        if self._date.day and 'X' not in self._date.day:
+            return EDTFFacetValue(
+                str(self._date.day),
+                str(self._date.day).lstrip('0'),
+            )
+        else:
+            return UNSPECIFIED_VALUE
+
+    def get_facets(self, prefix: str = '', suffix: str = ''):
+        return {
+            f'{prefix}millennium{suffix}': str(self.millennium),
+            f'{prefix}century{suffix}': str(self.century),
+            f'{prefix}decade{suffix}': str(self.decade),
+            f'{prefix}year{suffix}': str(self.year),
+            f'{prefix}month{suffix}': str(self.month),
+            f'{prefix}day{suffix}': str(self.day),
+        }
 
 
 class UnsupportedEDTFValue(ValueError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,3 +142,19 @@ def register_uri_for_reading():
             adding_headers={'Content-Type': content_type},
         )
     return _register_uri_for_reading
+
+
+@pytest.fixture
+def context_with_date():
+    def _context(edtf_value):
+        return IndexerContext(
+            repo=MagicMock(spec=Repository),
+            resource=MagicMock(spec=RepositoryResource),
+            model_class=ContentModeledResource,
+            doc={
+                'date__edtf': edtf_value,
+            },
+            config={},
+        )
+
+    return _context

--- a/tests/indexers/test_date_facets.py
+++ b/tests/indexers/test_date_facets.py
@@ -1,0 +1,113 @@
+import pytest
+from edtf import parse_edtf
+
+from solrizer.indexers.dates import EDTFFacets, date_fields
+
+DATE_FACET_TEST_VALUES = [
+    ('2026-04-07', {
+        'millennium': '2XXX|3rd Millennium (2000-2999)',
+        'century': '20XX|21st Century (2000-2099)',
+        'decade': '202X|2020s (2020-2029)',
+        'year': '2026|2026',
+        'month': '04|April',
+        'day': '07|7',
+    }),
+    ('1944-06', {
+        'millennium': '1XXX|2nd Millennium (1000-1999)',
+        'century': '19XX|20th Century (1900-1999)',
+        'decade': '194X|1940s (1940-1949)',
+        'year': '1944|1944',
+        'month': '06|June',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('1919', {
+        'millennium': '1XXX|2nd Millennium (1000-1999)',
+        'century': '19XX|20th Century (1900-1999)',
+        'decade': '191X|1910s (1910-1919)',
+        'year': '1919|1919',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('19XX', {
+        'millennium': '1XXX|2nd Millennium (1000-1999)',
+        'century': '19XX|20th Century (1900-1999)',
+        'decade': 'Unspecified|Unspecified',
+        'year': 'Unspecified|Unspecified',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('2XXX', {
+        'millennium': '2XXX|3rd Millennium (2000-2999)',
+        'century': 'Unspecified|Unspecified',
+        'decade': 'Unspecified|Unspecified',
+        'year': 'Unspecified|Unspecified',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('0891', {
+        'millennium': '0XXX|1st Millennium (0000-0999)',
+        'century': '08XX|9th Century (0800-0899)',
+        'decade': '089X|890s (0890-0899)',
+        'year': '0891|891',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('0033', {
+        'millennium': '0XXX|1st Millennium (0000-0999)',
+        'century': '00XX|1st Century (0000-0099)',
+        'decade': '003X|30s (0030-0039)',
+        'year': '0033|33',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('0002', {
+        'millennium': '0XXX|1st Millennium (0000-0999)',
+        'century': '00XX|1st Century (0000-0099)',
+        'decade': '000X|00s (0000-0009)',
+        'year': '0002|2',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('1066', {
+        'millennium': '1XXX|2nd Millennium (1000-1999)',
+        'century': '10XX|11th Century (1000-1099)',
+        'decade': '106X|1060s (1060-1069)',
+        'year': '1066|1066',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('1492', {
+        'millennium': '1XXX|2nd Millennium (1000-1999)',
+        'century': '14XX|15th Century (1400-1499)',
+        'decade': '149X|1490s (1490-1499)',
+        'year': '1492|1492',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+    ('1776', {
+        'millennium': '1XXX|2nd Millennium (1000-1999)',
+        'century': '17XX|18th Century (1700-1799)',
+        'decade': '177X|1770s (1770-1779)',
+        'year': '1776|1776',
+        'month': 'Unspecified|Unspecified',
+        'day': 'Unspecified|Unspecified',
+    }),
+]
+
+
+@pytest.mark.parametrize(
+    ('edtf_string', 'expected_facets'),
+    DATE_FACET_TEST_VALUES,
+)
+def test_edtf_facets_class(edtf_string, expected_facets):
+    assert EDTFFacets(parse_edtf(edtf_string)).get_facets() == expected_facets
+
+
+@pytest.mark.parametrize(
+    ('edtf_string', 'expected_facets'),
+    DATE_FACET_TEST_VALUES,
+)
+def test_date_fields_facets(context_with_date, edtf_string, expected_facets):
+    fields = date_fields(context_with_date(edtf_string))
+    for key, value in expected_facets.items():
+        assert fields[f'date_{key}__facet'] == value

--- a/tests/indexers/test_dates.py
+++ b/tests/indexers/test_dates.py
@@ -1,14 +1,10 @@
 from collections.abc import Iterable
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from edtf import EDTFParseException, parse_edtf
 from markdown_to_data import Markdown
-from plastron.models import ContentModeledResource
-from plastron.repo import Repository, RepositoryResource
 
-from solrizer.indexers import IndexerContext
 from solrizer.indexers.dates import UnsupportedEDTFValue, date_fields, solr_date, get_precision
 
 DOCS_DIR = Path(__file__).parents[2] / 'docs'
@@ -72,22 +68,6 @@ EDTF_PRECISIONS = get_param_set_from_markdown(
     file=(DOCS_DIR / 'EDTFtoDateRange.md'),
     columns=['EDTF', 'Precision'],
 )
-
-
-@pytest.fixture
-def context_with_date():
-    def _context(edtf_value):
-        return IndexerContext(
-            repo=MagicMock(spec=Repository),
-            resource=MagicMock(spec=RepositoryResource),
-            model_class=ContentModeledResource,
-            doc={
-                'date__edtf': edtf_value,
-            },
-            config={},
-        )
-
-    return _context
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
moved the `context_with_date` fixture to the conftest.py to share across test files

https://umd-dit.atlassian.net/browse/LIBFCREPO-1798