### PR TITLE
LIBFCREPO-1811. Assign prefix based on content model name.

### DIFF
--- a/src/solrizer/indexers/content_model.py
+++ b/src/solrizer/indexers/content_model.py
@@ -119,12 +119,23 @@ SKIP_FIELDS_BY_MODEL = {
 }
 """Field names that should be skipped for each model."""
 
+PREFIX_BY_MODEL = {
+    'Issue': 'object__',
+    'Item': 'object__',
+    'Letter': 'object__',
+    'Poster': 'object__',
+    'Page': 'page__',
+    'File': 'file__',
+    'AdminSet': 'adminset__',
+}
+"""Field name prefix to use for each model."""
+
 
 def content_model_fields(ctx: IndexerContext) -> SolrFields:
     """Indexer function that adds fields generated from the indexed
     resource's content model. Registered as the entry point
     *content_model* in the `solrizer_indexers` entry point group."""
-    return get_model_fields(ctx.obj, repo=ctx.repo, prefix='object__')
+    return get_model_fields(ctx.obj, repo=ctx.repo, prefix=get_prefix(ctx.model_class))
 
 
 def get_model_fields(obj: RDFResourceBase, repo: Repository, prefix: str = '') -> SolrFields:
@@ -312,14 +323,14 @@ def get_object_fields(prop: RDFObjectProperty, repo: Repository, prefix: str = '
             fields.update(get_model_fields(prop.object, repo=repo, prefix=prefix + prop.attr_name + '__'))
     elif prop.embedded:
         fields[prefix + prop.attr_name] = get_child_documents(
-            prefix=prop.object_class.__name__.lower() + '__',
+            prefix=get_prefix(prop.object_class),
             objects=prop.objects,
             repo=repo,
         )
     else:
         # linked object
         fields[prefix + prop.attr_name] = get_child_documents(
-            prefix=prop.object_class.__name__.lower() + '__',
+            prefix=get_prefix(prop.object_class),
             objects=get_linked_objects(prop, repo),
             repo=repo,
         )
@@ -350,6 +361,14 @@ def get_field(
         return {name: values}
     else:
         return {name: values[0]}
+
+
+def get_prefix(model_class: ContentModeledResource) -> str:
+    """Get the prefix for the given `model_class`. If there is no matching
+    prefix in the `PREFIX_BY_MODEL` dictionary, return the model class name,
+    converted to lowercase and appended with `__`."""
+    model_name: str = model_class.__name__
+    return PREFIX_BY_MODEL.get(model_name, model_name.lower() + '__')
 
 
 def shorten_uri(uri: str) -> str | None:

--- a/tests/indexers/test_content_model.py
+++ b/tests/indexers/test_content_model.py
@@ -6,8 +6,8 @@ import pytest
 from plastron.client import Endpoint
 from plastron.models import ContentModeledResource
 from plastron.models.authorities import Subject, UMD_ARCHIVAL_COLLECTIONS
-from plastron.models.page import File
-from plastron.models.umd import Item
+from plastron.models.page import File, Page
+from plastron.models.umd import Item, AdminSet
 from plastron.namespaces import umdtype, rdf, xsd, dcterms, owl
 from plastron.rdfmapping.descriptors import DataProperty
 from plastron.rdfmapping.properties import RDFDataProperty, RDFObjectProperty
@@ -423,3 +423,18 @@ def test_get_model_fields_display_value_without_resource_language():
     obj = SimpleModel(title=[Literal('Hund', lang='de'), Literal('Dog', 'en')])
     fields = get_model_fields(obj, mock_repo)
     assert fields['title__display'] == ['[@de]Hund', '[@en]Dog']
+
+
+@pytest.mark.parametrize(
+    ('obj', 'expected_field', 'expected_value'),
+    [
+        (Item(title=Literal('bar')), 'object__title__txt', 'bar'),
+        (Page(title=Literal('foo')), 'page__title__txt', 'foo'),
+        (File(filename=Literal('foo.txt')), 'file__filename__str', 'foo.txt'),
+        (AdminSet(title=Literal('stuff')), 'adminset__title__txt', 'stuff'),
+    ]
+)
+def test_content_model_fields(get_mock_context, obj, expected_field, expected_value):
+    doc = content_model_fields(get_mock_context(obj))
+    assert expected_field in doc
+    assert doc[expected_field] == expected_value


### PR DESCRIPTION
- do not assume that the initial entry point to indexing is always a top-level resource that gets the field prefix `object__`.
- default to the lowercased model name plus "__" if the model name cannot be found in the `PREFIX_BY_MODEL` dictionary

https://umd-dit.atlassian.net/browse/LIBFCREPO-1811